### PR TITLE
Use deriveGeneric to derive tuple instances up to 30 components.

### DIFF
--- a/src/Generics/SOP/Instances.hs
+++ b/src/Generics/SOP/Instances.hs
@@ -67,6 +67,21 @@ deriveGeneric ''(,,,,,,,,,,,)
 deriveGeneric ''(,,,,,,,,,,,,)
 deriveGeneric ''(,,,,,,,,,,,,,)
 deriveGeneric ''(,,,,,,,,,,,,,,) -- 15
+deriveGeneric ''(,,,,,,,,,,,,,,,)
+deriveGeneric ''(,,,,,,,,,,,,,,,,)
+deriveGeneric ''(,,,,,,,,,,,,,,,,,)
+deriveGeneric ''(,,,,,,,,,,,,,,,,,,)
+deriveGeneric ''(,,,,,,,,,,,,,,,,,,,) -- 20
+deriveGeneric ''(,,,,,,,,,,,,,,,,,,,,)
+deriveGeneric ''(,,,,,,,,,,,,,,,,,,,,,)
+deriveGeneric ''(,,,,,,,,,,,,,,,,,,,,,,)
+deriveGeneric ''(,,,,,,,,,,,,,,,,,,,,,,,)
+deriveGeneric ''(,,,,,,,,,,,,,,,,,,,,,,,,) -- 25
+deriveGeneric ''(,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriveGeneric ''(,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriveGeneric ''(,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriveGeneric ''(,,,,,,,,,,,,,,,,,,,,,,,,,,,,)
+deriveGeneric ''(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,) -- 30
 deriveGeneric ''[]
 
 -- Other types from base:


### PR DESCRIPTION
I actually need this, I'm so sorry.
