### PR TITLE
SingI x to the context of Shape

### DIFF
--- a/src/Generics/SOP/Sing.hs
+++ b/src/Generics/SOP/Sing.hs
@@ -83,7 +83,7 @@ instance (SingI x, SingI xs) => SingI (x ': xs) where
 -- of type-level lists (esp because of https://ghc.haskell.org/trac/ghc/ticket/9108)
 data Shape :: [k] -> * where
   ShapeNil  :: Shape '[]
-  ShapeCons :: SingI xs => Shape xs -> Shape (x ': xs)
+  ShapeCons :: (SingI x, SingI xs) => Shape xs -> Shape (x ': xs)
 
 deriving instance Show (Shape xs)
 deriving instance Eq   (Shape xs)


### PR DESCRIPTION
I found that I had to recurse with both `Sing a` and `Shape a`. This allows one to only use `Shape a`.