### PR TITLE
Fix default signatures for GHC 8.2

### DIFF
--- a/src/Generics/SOP/Universe.hs
+++ b/src/Generics/SOP/Universe.hs
@@ -115,13 +115,15 @@ class (All SListI (Code a)) => Generic (a :: *) where
 
   -- | Converts from a value to its structural representation.
   from         :: a -> Rep a
-  default from :: (GFrom a, GHC.Generic a) => a -> SOP I (GCode a)
+  default from :: (GFrom a, GHC.Generic a, Rep a ~ SOP I (GCode a))
+               => a -> Rep a
   from = gfrom
 
   -- | Converts from a structural representation back to the
   -- original value.
   to         :: Rep a -> a
-  default to :: (GTo a, GHC.Generic a) => SOP I (GCode a) -> a
+  default to :: (GTo a, GHC.Generic a, Rep a ~ SOP I (GCode a))
+             => Rep a -> a
   to = gto
 
 -- | A class of datatypes that have associated metadata.
@@ -136,5 +138,6 @@ class (All SListI (Code a)) => Generic (a :: *) where
 --
 class HasDatatypeInfo a where
   datatypeInfo         :: proxy a -> DatatypeInfo (Code a)
-  default datatypeInfo :: GDatatypeInfo a => proxy a -> DatatypeInfo (GCode a)
+  default datatypeInfo :: (GDatatypeInfo a, Code a ~ GCode a)
+                       => proxy a -> DatatypeInfo (Code a)
   datatypeInfo = gdatatypeInfo


### PR DESCRIPTION
GHC now checks that default signatures differ from their method only in
their contexts.