### PR TITLE
apInjs'_POP and apInjs'_NP

### DIFF
--- a/doctest.sh
+++ b/doctest.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -ex
+
+doctest \
+  -XCPP \
+  -XScopedTypeVariables \
+  -XTypeFamilies \
+  -XRankNTypes \
+  -XTypeOperators \
+  -XGADTs \
+  -XConstraintKinds \
+  -XMultiParamTypeClasses \
+  -XTypeSynonymInstances \
+  -XFlexibleInstances \
+  -XFlexibleContexts \
+  -XDeriveFunctor \
+  -XDeriveFoldable \
+  -XDeriveTraversable \
+  -XDefaultSignatures \
+  -XKindSignatures \
+  -XDataKinds \
+  -XFunctionalDependencies \
+  $(find src -name '*.hs')

--- a/src/Generics/SOP/Classes.hs
+++ b/src/Generics/SOP/Classes.hs
@@ -518,3 +518,6 @@ class HExpand (h :: (k -> *) -> (l -> *)) where
   -- @since 0.2.5.0
   --
   hcexpand :: (AllN (Prod h) c xs) => proxy c -> (forall x . c x => f x) -> h f xs -> Prod h f xs
+
+-- $setup
+-- >>> import Generics.SOP

--- a/src/Generics/SOP/NS.hs
+++ b/src/Generics/SOP/NS.hs
@@ -16,7 +16,9 @@ module Generics.SOP.NS
   , shift
   , shiftInjection
   , apInjs_NP
+  , apInjs'_NP
   , apInjs_POP
+  , apInjs'_POP
     -- * Destructing sums
   , unZ
   , index_NS
@@ -258,7 +260,15 @@ shift = shiftInjection
 -- [Z (I 'x'), S (Z (I True)), S (S (Z (I 2)))]
 --
 apInjs_NP  :: SListI xs  => NP  f xs  -> [NS  f xs]
-apInjs_NP  = hcollapse . hap injections
+apInjs_NP  = hcollapse . apInjs'_NP
+
+-- | `apInjs_NP` without `hcollapse`.
+--
+-- >>> apInjs'_NP (I 'x' :* I True :* I 2 :* Nil)
+-- K (Z (I 'x')) :* K (S (Z (I True))) :* K (S (S (Z (I 2)))) :* Nil
+--
+apInjs'_NP :: SListI xss => NP f xss -> NP (K (NS f xss)) xss
+apInjs'_NP = hap injections
 
 -- | Apply injections to a product of product.
 --
@@ -274,6 +284,16 @@ apInjs_NP  = hcollapse . hap injections
 --
 apInjs_POP :: SListI xss => POP f xss -> [SOP f xss]
 apInjs_POP = map SOP . apInjs_NP . unPOP
+
+-- | `apInjs_POP` without `hcollapse`.
+--
+-- /Example:/
+--
+-- >>> apInjs'_POP (POP ((I 'x' :* Nil) :* (I True :* I 2 :* Nil) :* Nil))
+-- K (SOP (Z (I 'x' :* Nil))) :* K (SOP (S (Z (I True :* I 2 :* Nil)))) :* Nil
+--
+apInjs'_POP :: SListI xss => POP f xss -> NP (K (SOP f xss)) xss
+apInjs'_POP = hmap (\(K xss) -> K (SOP xss)) . hap injections . unPOP
 
 type instance UnProd NP  = NS
 type instance UnProd POP = SOP


### PR DESCRIPTION
Resolves https://github.com/well-typed/generics-sop/issues/28

I didn't add `hapInjs'`, it's signature is

```haskell
class (UnProd (Prod h) ~ h) => HApInjs' (h :: (k -> *) -> (l -> *)) where
  hapInjs' :: (SListIN h xs) => Prod h f xs -> NP (K (h f xs)) xs
```
but we don't yet know about `NP` in `Classes.hs`

*EDIT* doctests don't pass, as derived `Show` adds parentheses (i.e. doesn't take fixity into account); we can change `Show` or leave it alone; `doctest.sh` is still useful to give quick overview