### PR TITLE
AllZip and trans_*

### DIFF
--- a/generics-sop.cabal
+++ b/generics-sop.cabal
@@ -104,6 +104,7 @@ library
 test-suite generic-sop-examples
   type:                exitcode-stdio-1.0
   main-is:             Example.hs
+  other-modules:       HTransExample
   hs-source-dirs:      test
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/generics-sop.cabal
+++ b/generics-sop.cabal
@@ -101,7 +101,7 @@ library
   if impl (ghc < 7.10)
     other-extensions:    OverlappingInstances
 
-test-suite generic-sop-examples
+test-suite generics-sop-examples
   type:                exitcode-stdio-1.0
   main-is:             Example.hs
   other-modules:       HTransExample

--- a/src/Generics/SOP.hs
+++ b/src/Generics/SOP.hs
@@ -296,6 +296,10 @@ module Generics.SOP (
   , hsequenceK
     -- ** Expanding sums to products
   , HExpand(..)
+    -- ** Transformation of index lists and coercions
+  , HTrans(..)
+  , hfromI
+  , htoI
     -- ** Partial operations
   , fromList
     -- * Utilities
@@ -322,10 +326,16 @@ module Generics.SOP (
     -- ** Mapping constraints
   , All
   , All2
+  , AllZip
+  , AllZip2
+  , AllN
+  , AllZipN
+    -- ** Other constraints
   , Compose
   , And
   , Top
-  , AllN
+  , LiftedCoercible
+  , SameShapeAs
     -- ** Singletons
   , SList(..)
   , SListI(..)

--- a/src/Generics/SOP/Classes.hs
+++ b/src/Generics/SOP/Classes.hs
@@ -70,7 +70,7 @@ module Generics.SOP.Classes
   , HApInjs(..)
     -- * Expanding sums to products
   , HExpand(..)
-    -- * Transforming index lists
+    -- * Transformation of index lists and coercions
   , HTrans(..)
   , hfromI
   , htoI

--- a/src/Generics/SOP/Classes.hs
+++ b/src/Generics/SOP/Classes.hs
@@ -527,22 +527,52 @@ class HExpand (h :: (k -> *) -> (l -> *)) where
   --
   hcexpand :: (AllN (Prod h) c xs) => proxy c -> (forall x . c x => f x) -> h f xs -> Prod h f xs
 
+-- | A class for transforming structures into related structures with
+-- a different index list, as long as the index lists have the same shape
+-- and the elements and interpretation functions are suitably related.
+--
+-- @since 0.3.1.0
+--
 class (Same h1 ~ h2, Same h2 ~ h1) => HTrans (h1 :: (k1 -> *) -> (l1 -> *)) (h2 :: (k2 -> *) -> (l2 -> *)) where
+
+  -- | Transform a structure into a related structure given a conversion
+  -- function for the elements.
+  --
+  -- @since 0.3.1.0
+  --
   htrans ::
        AllZipN (Prod h1) c xs ys
     => proxy c
     -> (forall x y . c x y => f x -> g y)
     -> h1 f xs -> h2 g ys
 
+  -- | Coerce a structure into a representationally equal structure.
+  --
+  -- /Examples:/
+  --
+  -- >>> hcoerce (I (Just LT) :* I (Just 'x') :* I (Just True) :* Nil) :: NP Maybe '[Ordering, Char, Bool]
+  -- Just LT :* (Just 'x' :* (Just True :* Nil))
+  -- >>> hcoerce (SOP (Z (K True :* K False :* Nil))) :: SOP I '[ '[Bool, Bool], '[Bool] ]
+  -- SOP (Z (I True :* (I False :* Nil)))
+  --
+  -- @since 0.3.1.0
   hcoerce ::
        (AllZipN (Prod h1) (LiftedCoercible f g) xs ys, HTrans h1 h2)
     => h1 f xs -> h2 g ys
 
+-- | Specialization of 'hcoerce'.
+--
+-- @since 0.3.1.0
+--
 hfromI ::
        (AllZipN (Prod h1) (LiftedCoercible I f) xs ys, HTrans h1 h2)
     => h1 I xs -> h2 f ys
 hfromI = hcoerce
 
+-- | Specialization of 'hcoerce'.
+--
+-- @since 0.3.1.0
+--
 htoI ::
        (AllZipN (Prod h1) (LiftedCoercible f I) xs ys, HTrans h1 h2)
     => h1 f xs -> h2 I ys

--- a/src/Generics/SOP/Constraint.hs
+++ b/src/Generics/SOP/Constraint.hs
@@ -17,7 +17,9 @@ module Generics.SOP.Constraint
   , Constraint
   ) where
 
+import Data.Coerce
 import GHC.Exts (Constraint)
+
 import Generics.SOP.Sing
 
 -- | Require a constraint for every element of a list.
@@ -46,9 +48,10 @@ instance (AllF f xs, SListI xs) => All f xs
 
 -- | Type family used to implement 'All'.
 --
-type family AllF (c :: k -> Constraint) (xs :: [k]) :: Constraint
-type instance AllF _c '[]       = ()
-type instance AllF  c (x ': xs) = (c x, All c xs)
+type family
+  AllF (c :: k -> Constraint) (xs :: [k]) :: Constraint where
+  AllF _c '[]       = ()
+  AllF  c (x ': xs) = (c x, All c xs)
 
 -- | Require a singleton for every inner list in a list of lists.
 type SListI2 = All SListI
@@ -86,6 +89,83 @@ instance (AllF (All f) xss, SListI xss) => All2 f xss
 -- is more direct, but has the unfortunate disadvantage the
 -- it triggers GHC's superclass cycle check when used in a
 -- class context.
+
+-- | Require a constraint for pointwise for every pair of
+-- elements from two lists.
+--
+-- /Example:/ The constraint
+--
+-- > All (~) '[ Int, Bool, Char ] '[ a, b, c ]
+--
+-- is equivalent to the constraint
+--
+-- > (Int ~ a, Bool ~ b, Char ~ c)
+--
+-- @since 0.3.1.0
+--
+class
+  ( SListI xs, SListI ys
+  , SameShapeAs xs ys, SameShapeAs ys xs
+  , AllZipF c xs ys
+  ) => AllZip (c :: a -> b -> Constraint) (xs :: [a]) (ys :: [b])
+instance
+  ( SListI xs, SListI ys
+  , SameShapeAs xs ys, SameShapeAs ys xs
+  , AllZipF c xs ys
+  ) => AllZip c xs ys
+
+-- | Type family used to implement 'AllZip'.
+--
+-- @since 0.3.1.0
+--
+type family
+  AllZipF (c :: a -> b -> Constraint) (xs :: [a]) (ys :: [b])
+    :: Constraint where
+  AllZipF _c '[]      '[]        = ()
+  AllZipF  c (x ': xs) (y ': ys) = (c x y, AllZip c xs ys)
+
+-- | Type family that forces a type-level list to be of the same
+-- shape as the given type-level list.
+--
+-- The main use of this constraint is to help type inference to
+-- learn something about otherwise unknown type-level lists.
+--
+-- @since 0.3.1.0
+--
+type family
+  SameShapeAs (xs :: [a]) (ys :: [b]) :: Constraint where
+  SameShapeAs '[]       ys = (ys ~ '[])
+  SameShapeAs (x ': xs) ys =
+    (ys ~ (Head ys ': Tail ys), SameShapeAs xs (Tail ys))
+
+-- | Utility function to compute the head of a type-level list.
+--
+-- @since 0.3.1.0
+--
+type family Head (xs :: [a]) :: a where
+  Head (x ': xs) = x
+
+-- | Utility function to compute the tail of a type-level list.
+--
+-- @since 0.3.1.0
+--
+type family Tail (xs :: [a]) :: [a] where
+  Tail (x ': xs) = xs
+
+-- | The constraint @LiftedCoercible f g x y@ is equivalent
+-- to @Coercible (f x) (g y)@.
+--
+-- @since 0.3.1.0
+--
+class Coercible (f x) (g y) => LiftedCoercible f g x y
+instance Coercible (f x) (g y) => LiftedCoercible f g x y
+
+-- | Require a constraint for pointwise for every pair of
+-- elements from two lists of lists.
+--
+--
+class (AllZipF (AllZip f) xss yss, SListI xss, SListI yss, SameShapeAs xss yss, SameShapeAs yss xss) => AllZip2 f xss yss
+instance (AllZipF (AllZip f) xss yss, SListI xss, SListI yss, SameShapeAs xss yss, SameShapeAs yss xss) => AllZip2 f xss yss
 
 -- | Composition of constraints.
 --

--- a/src/Generics/SOP/Constraint.hs
+++ b/src/Generics/SOP/Constraint.hs
@@ -206,6 +206,13 @@ instance Top x
 --
 type family AllN (h :: (k -> *) -> (l -> *)) (c :: k -> Constraint) :: l -> Constraint
 
+-- | A generalization of 'AllZip' and 'AllZip2'.
+--
+-- The family 'AllZipN' expands to 'AllZip' or 'AllZip2' depending on
+-- whther the argument is indexed by a list or a list of lists.
+--
+type family AllZipN (h :: (k -> *) -> (l -> *)) (c :: k1 -> k2 -> Constraint) :: l1 -> l2 -> Constraint
+
 -- | A generalization of 'SListI'.
 --
 -- The family 'SListIN' expands to 'SListI' or 'SListI2' depending

--- a/src/Generics/SOP/NP.hs
+++ b/src/Generics/SOP/NP.hs
@@ -64,12 +64,23 @@ module Generics.SOP.NP
   , ccata_NP
   , ana_NP
   , cana_NP
+    -- * Transformations and coercions
+  , trans_NP
+  , trans_POP
+  , coerce_NP
+  , coerce_POP
+  , fromI_NP
+  , fromI_POP
+  , toI_NP
+  , toI_POP
   ) where
 
 #if !(MIN_VERSION_base(4,8,0))
 import Control.Applicative
 #endif
+import Data.Coerce
 import Data.Proxy (Proxy(..))
+import Unsafe.Coerce
 
 import Control.DeepSeq (NFData(..))
 
@@ -602,3 +613,79 @@ cana_NP _ uncons = go sList
     go SNil  _ = Nil
     go SCons s = case uncons s of
       (x, s') -> x :* go sList s'
+
+-- | Transform an 'NP' into a related 'NP' given a conversion
+-- function for the elements.
+--
+-- @since 0.3.1.0
+--
+trans_NP ::
+     AllZip c xs ys
+  => proxy c
+  -> (forall x y . c x y => f x -> g y)
+  -> NP f xs -> NP g ys
+trans_NP _ _t Nil       = Nil
+trans_NP p  t (x :* xs) = t x :* trans_NP p t xs
+
+trans_POP ::
+     AllZip2 c xss yss
+  => proxy c
+  -> (forall x y . c x y => f x -> g y)
+  -> POP f xss -> POP g yss
+trans_POP p t =
+  POP . trans_NP (allZipP p) (trans_NP p t) . unPOP
+
+allZipP :: proxy c -> Proxy (AllZip c)
+allZipP _ = Proxy
+
+coerce_NP ::
+     forall f g xs ys .
+     AllZip (LiftedCoercible f g) xs ys
+  => NP f xs -> NP g ys
+coerce_NP =
+  unsafeCoerce
+
+_safe_coerce_NP ::
+     forall f g xs ys .
+     AllZip (LiftedCoercible f g) xs ys
+  => NP f xs -> NP g ys
+_safe_coerce_NP =
+  trans_NP (Proxy :: Proxy (LiftedCoercible f g)) coerce
+
+coerce_POP ::
+     forall f g xss yss .
+     AllZip2 (LiftedCoercible f g) xss yss
+  => POP f xss -> POP g yss
+coerce_POP =
+  unsafeCoerce
+
+_safe_coerce_POP ::
+     forall f g xss yss .
+     AllZip2 (LiftedCoercible f g) xss yss
+  => POP f xss -> POP g yss
+_safe_coerce_POP =
+  trans_POP (Proxy :: Proxy (LiftedCoercible f g)) coerce
+
+fromI_NP ::
+     forall f xs ys .
+     AllZip (LiftedCoercible I f) xs ys
+  => NP I xs -> NP f ys
+fromI_NP = coerce_NP
+
+toI_NP ::
+     forall f xs ys .
+     AllZip (LiftedCoercible f I) xs ys
+  => NP f xs -> NP I ys
+toI_NP = coerce_NP
+
+fromI_POP ::
+     forall f xss yss .
+     AllZip2 (LiftedCoercible I f) xss yss
+  => POP I xss -> POP f yss
+fromI_POP = coerce_POP
+
+toI_POP ::
+     forall f xss yss .
+     AllZip2 (LiftedCoercible f I) xss yss
+  => POP f xss -> POP I yss
+toI_POP = coerce_POP

--- a/src/Generics/SOP/NP.hs
+++ b/src/Generics/SOP/NP.hs
@@ -64,7 +64,7 @@ module Generics.SOP.NP
   , ccata_NP
   , ana_NP
   , cana_NP
-    -- * Transformations and coercions
+    -- * Transformation of index lists and coercions
   , trans_NP
   , trans_POP
   , coerce_NP

--- a/src/Generics/SOP/NP.hs
+++ b/src/Generics/SOP/NP.hs
@@ -645,12 +645,21 @@ coerce_NP ::
 coerce_NP =
   unsafeCoerce
 
+-- There is a bug in the way coerce works for higher-kinded
+-- type variables that seems to occur only in GHC 7.10.
+--
+-- Therefore, the safe versions of the coercion functions
+-- are excluded below. This is harmless because they're only
+-- present for documentation purposes and not exported.
+
+#if __GLASGOW_HASKELL__ < 710 || __GLASGOW_HASKELL__ >= 800
 _safe_coerce_NP ::
      forall f g xs ys .
      AllZip (LiftedCoercible f g) xs ys
   => NP f xs -> NP g ys
 _safe_coerce_NP =
   trans_NP (Proxy :: Proxy (LiftedCoercible f g)) coerce
+#endif
 
 coerce_POP ::
      forall f g xss yss .
@@ -659,12 +668,14 @@ coerce_POP ::
 coerce_POP =
   unsafeCoerce
 
+#if __GLASGOW_HASKELL__ < 710 || __GLASGOW_HASKELL__ >= 800
 _safe_coerce_POP ::
      forall f g xss yss .
      AllZip2 (LiftedCoercible f g) xss yss
   => POP f xss -> POP g yss
 _safe_coerce_POP =
   trans_POP (Proxy :: Proxy (LiftedCoercible f g)) coerce
+#endif
 
 fromI_NP ::
      forall f xs ys .

--- a/src/Generics/SOP/NP.hs
+++ b/src/Generics/SOP/NP.hs
@@ -620,8 +620,7 @@ cana_NP _ uncons = go sList
     go SCons s = case uncons s of
       (x, s') -> x :* go sList s'
 
--- | Transform an 'NP' into a related 'NP' given a conversion
--- function for the elements.
+-- | Specialization of 'htrans'.
 --
 -- @since 0.3.1.0
 --
@@ -633,6 +632,10 @@ trans_NP ::
 trans_NP _ _t Nil       = Nil
 trans_NP p  t (x :* xs) = t x :* trans_NP p t xs
 
+-- | Specialization of 'htrans'.
+--
+-- @since 0.3.1.0
+--
 trans_POP ::
      AllZip2 c xss yss
   => proxy c
@@ -644,6 +647,10 @@ trans_POP p t =
 allZipP :: proxy c -> Proxy (AllZip c)
 allZipP _ = Proxy
 
+-- | Specialization of 'hcoerce'.
+--
+-- @since 0.3.1.0
+--
 coerce_NP ::
      forall f g xs ys .
      AllZip (LiftedCoercible f g) xs ys
@@ -667,6 +674,10 @@ _safe_coerce_NP =
   trans_NP (Proxy :: Proxy (LiftedCoercible f g)) coerce
 #endif
 
+-- | Specialization of 'hcoerce'.
+--
+-- @since 0.3.1.0
+--
 coerce_POP ::
      forall f g xss yss .
      AllZip2 (LiftedCoercible f g) xss yss
@@ -683,24 +694,40 @@ _safe_coerce_POP =
   trans_POP (Proxy :: Proxy (LiftedCoercible f g)) coerce
 #endif
 
+-- | Specialization of 'hfromI'.
+--
+-- @since 0.3.1.0
+--
 fromI_NP ::
      forall f xs ys .
      AllZip (LiftedCoercible I f) xs ys
   => NP I xs -> NP f ys
 fromI_NP = hfromI
 
+-- | Specialization of 'htoI'.
+--
+-- @since 0.3.1.0
+--
 toI_NP ::
      forall f xs ys .
      AllZip (LiftedCoercible f I) xs ys
   => NP f xs -> NP I ys
 toI_NP = htoI
 
+-- | Specialization of 'hfromI'.
+--
+-- @since 0.3.1.0
+--
 fromI_POP ::
      forall f xss yss .
      AllZip2 (LiftedCoercible I f) xss yss
   => POP I xss -> POP f yss
 fromI_POP = hfromI
 
+-- | Specialization of 'htoI'.
+--
+-- @since 0.3.1.0
+--
 toI_POP ::
      forall f xss yss .
      AllZip2 (LiftedCoercible f I) xss yss

--- a/src/Generics/SOP/NP.hs
+++ b/src/Generics/SOP/NP.hs
@@ -163,6 +163,9 @@ unPOP (POP xss) = xss
 type instance AllN NP  c = All  c
 type instance AllN POP c = All2 c
 
+type instance AllZipN NP  c = AllZip  c
+type instance AllZipN POP c = AllZip2 c
+
 type instance SListIN NP  = SListI
 type instance SListIN POP = SListI2
 
@@ -276,6 +279,9 @@ ap_POP (POP fss') (POP xss') = POP (go fss' xss')
 -- that it avoids the 'SListI' constraint.
 _ap_POP_spec :: SListI xss => POP (f -.-> g) xss -> POP  f xss -> POP  g xss
 _ap_POP_spec (POP fs) (POP xs) = POP (liftA2_NP ap_NP fs xs)
+
+type instance Same NP  = NP
+type instance Same POP = POP
 
 type instance Prod NP  = NP
 type instance Prod POP = POP
@@ -681,22 +687,29 @@ fromI_NP ::
      forall f xs ys .
      AllZip (LiftedCoercible I f) xs ys
   => NP I xs -> NP f ys
-fromI_NP = coerce_NP
+fromI_NP = hfromI
 
 toI_NP ::
      forall f xs ys .
      AllZip (LiftedCoercible f I) xs ys
   => NP f xs -> NP I ys
-toI_NP = coerce_NP
+toI_NP = htoI
 
 fromI_POP ::
      forall f xss yss .
      AllZip2 (LiftedCoercible I f) xss yss
   => POP I xss -> POP f yss
-fromI_POP = coerce_POP
+fromI_POP = hfromI
 
 toI_POP ::
      forall f xss yss .
      AllZip2 (LiftedCoercible f I) xss yss
   => POP f xss -> POP I yss
-toI_POP = coerce_POP
+toI_POP = htoI
+
+instance HTrans NP NP where
+  htrans  = trans_NP
+  hcoerce = coerce_NP
+instance HTrans POP POP where
+  htrans  = trans_POP
+  hcoerce = coerce_POP

--- a/src/Generics/SOP/NS.hs
+++ b/src/Generics/SOP/NS.hs
@@ -353,6 +353,9 @@ ap_SOP (POP fss') (SOP xss') = SOP (go fss' xss')
 _ap_SOP_spec :: SListI xss => POP (t -.-> f) xss -> SOP t xss -> SOP f xss
 _ap_SOP_spec (POP fs) (SOP xs) = SOP (liftA2_NS ap_NP fs xs)
 
+type instance Same NS  = NS
+type instance Same SOP = SOP
+
 type instance Prod NS  = NP
 type instance Prod SOP = POP
 
@@ -670,22 +673,30 @@ fromI_NS ::
      forall f xs ys .
      AllZip (LiftedCoercible I f) xs ys
   => NS I xs -> NS f ys
-fromI_NS = coerce_NS
+fromI_NS = hfromI
 
 toI_NS ::
      forall f xs ys .
      AllZip (LiftedCoercible f I) xs ys
   => NS f xs -> NS I ys
-toI_NS = coerce_NS
+toI_NS = htoI
 
 fromI_SOP ::
      forall f xss yss .
      AllZip2 (LiftedCoercible I f) xss yss
   => SOP I xss -> SOP f yss
-fromI_SOP = coerce_SOP
+fromI_SOP = hfromI
 
 toI_SOP ::
      forall f xss yss .
      AllZip2 (LiftedCoercible f I) xss yss
   => SOP f xss -> SOP I yss
-toI_SOP = coerce_SOP
+toI_SOP = htoI
+
+instance HTrans NS NS where
+  htrans  = trans_NS
+  hcoerce = coerce_NS
+
+instance HTrans SOP SOP where
+  htrans  = trans_SOP
+  hcoerce = coerce_SOP

--- a/src/Generics/SOP/NS.hs
+++ b/src/Generics/SOP/NS.hs
@@ -634,12 +634,21 @@ coerce_NS ::
 coerce_NS =
   unsafeCoerce
 
+-- There is a bug in the way coerce works for higher-kinded
+-- type variables that seems to occur only in GHC 7.10.
+--
+-- Therefore, the safe versions of the coercion functions
+-- are excluded below. This is harmless because they're only
+-- present for documentation purposes and not exported.
+
+#if __GLASGOW_HASKELL__ < 710 || __GLASGOW_HASKELL__ >= 800
 _safe_coerce_NS ::
      forall f g xs ys .
      AllZip (LiftedCoercible f g) xs ys
   => NS f xs -> NS g ys
 _safe_coerce_NS =
   trans_NS (Proxy :: Proxy (LiftedCoercible f g)) coerce
+#endif
 
 coerce_SOP ::
      forall f g xss yss .
@@ -648,12 +657,14 @@ coerce_SOP ::
 coerce_SOP =
   unsafeCoerce
 
+#if __GLASGOW_HASKELL__ < 710 || __GLASGOW_HASKELL__ >= 800
 _safe_coerce_SOP ::
      forall f g xss yss .
      AllZip2 (LiftedCoercible f g) xss yss
   => SOP f xss -> SOP g yss
 _safe_coerce_SOP =
   trans_SOP (Proxy :: Proxy (LiftedCoercible f g)) coerce
+#endif
 
 fromI_NS ::
      forall f xs ys .

--- a/src/Generics/SOP/NS.hs
+++ b/src/Generics/SOP/NS.hs
@@ -606,8 +606,7 @@ instance HExpand SOP where
   hexpand  = expand_SOP
   hcexpand = cexpand_SOP
 
--- | Transform an 'NS' into a related 'NS' given a conversion
--- function for the elements.
+-- | Specialization of 'htrans'.
 --
 -- @since 0.3.1.0
 --
@@ -619,6 +618,10 @@ trans_NS ::
 trans_NS _ t (Z x)      = Z (t x)
 trans_NS p t (S x)      = S (trans_NS p t x)
 
+-- | Specialization of 'htrans'.
+--
+-- @since 0.3.1.0
+--
 trans_SOP ::
      AllZip2 c xss yss
   => proxy c
@@ -630,6 +633,10 @@ trans_SOP p t =
 allZipP :: proxy c -> Proxy (AllZip c)
 allZipP _ = Proxy
 
+-- | Specialization of 'hcoerce'.
+--
+-- @since 0.3.1.0
+--
 coerce_NS ::
      forall f g xs ys .
      AllZip (LiftedCoercible f g) xs ys
@@ -653,6 +660,10 @@ _safe_coerce_NS =
   trans_NS (Proxy :: Proxy (LiftedCoercible f g)) coerce
 #endif
 
+-- | Specialization of 'hcoerce'.
+--
+-- @since 0.3.1.0
+--
 coerce_SOP ::
      forall f g xss yss .
      AllZip2 (LiftedCoercible f g) xss yss
@@ -669,24 +680,40 @@ _safe_coerce_SOP =
   trans_SOP (Proxy :: Proxy (LiftedCoercible f g)) coerce
 #endif
 
+-- | Specialization of 'hfromI'.
+--
+-- @since 0.3.1.0
+--
 fromI_NS ::
      forall f xs ys .
      AllZip (LiftedCoercible I f) xs ys
   => NS I xs -> NS f ys
 fromI_NS = hfromI
 
+-- | Specialization of 'htoI'.
+--
+-- @since 0.3.1.0
+--
 toI_NS ::
      forall f xs ys .
      AllZip (LiftedCoercible f I) xs ys
   => NS f xs -> NS I ys
 toI_NS = htoI
 
+-- | Specialization of 'hfromI'.
+--
+-- @since 0.3.1.0
+--
 fromI_SOP ::
      forall f xss yss .
      AllZip2 (LiftedCoercible I f) xss yss
   => SOP I xss -> SOP f yss
 fromI_SOP = hfromI
 
+-- | Specialization of 'htoI'.
+--
+-- @since 0.3.1.0
+--
 toI_SOP ::
      forall f xss yss .
      AllZip2 (LiftedCoercible f I) xss yss

--- a/src/Generics/SOP/NS.hs
+++ b/src/Generics/SOP/NS.hs
@@ -59,7 +59,7 @@ module Generics.SOP.NS
   , cexpand_NS
   , expand_SOP
   , cexpand_SOP
-    -- * Transformations and coercions
+    -- * Transformation of index lists and coercions
   , trans_NS
   , trans_SOP
   , coerce_NS

--- a/test/Example.hs
+++ b/test/Example.hs
@@ -12,6 +12,8 @@ import Generics.SOP
 import Generics.SOP.TH
 import qualified Generics.SOP.Type.Metadata as T
 
+import HTransExample
+
 -- Generic show, kind of
 gshow :: (Generic a, All2 Show (Code a)) => a -> String
 gshow x = gshowS (from x)
@@ -76,3 +78,4 @@ main = do
   print treeDatatypeInfo
   print demotedTreeDatatypeInfo
   print (treeDatatypeInfo == demotedTreeDatatypeInfo)
+  print $ convertFull tree

--- a/test/HTransExample.hs
+++ b/test/HTransExample.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+module HTransExample where
+
+import Generics.SOP
+
+class IsTupleTypeOf xs y | xs -> y where
+  toTuple :: NP I xs -> y
+  default toTuple :: (Generic y, Code y ~ '[ xs ]) => NP I xs -> y
+  toTuple = to . SOP . Z
+
+instance IsTupleTypeOf '[] ()
+instance IsTupleTypeOf '[x1] x1 where toTuple = unI . hd
+instance IsTupleTypeOf '[x1, x2] (x1, x2)
+instance IsTupleTypeOf '[x1, x2, x3] (x1, x2, x3)
+instance IsTupleTypeOf '[x1, x2, x3, x4] (x1, x2, x3, x4)
+
+convert :: (AllZip IsTupleTypeOf xss ys) => NS (NP I) xss -> NS I ys
+convert = htrans (Proxy :: Proxy IsTupleTypeOf) (I . toTuple)
+
+convertFull :: (Generic a, AllZip IsTupleTypeOf (Code a) ys) => a -> NS I ys
+convertFull = convert . unSOP . from


### PR DESCRIPTION
This introduces one of the most frequently requested features.

All the current functions operating on NPs, NSs, SOPs, POPs, leave what I call the "signature" of the structure unchanged. The "signature" being the type-level list (of lists) describing the contents of the structure. Only the "interpretation" (i.e., the type constructor) can be changed.

This, however, breaks down if we want to convert between truly different datatypes, or exploit that a datatype's components adhere to a particular property. An example would be that a datatype has fields that are all wrapped in a Maybe application, and you'd like to turn it into an `SOP Maybe ...` rather than an `SOP I ...`.

For this conversion, `fromI_SOP` and `toI_SOP` are now offered. The `coerce_*` and `trans_*` functions offer more general variants of these functions.

I consider this in principle ready to merge, perhaps modulo adding more/better documentation and possible bikeshedding about the names. The PR only adds new functionality and does not change existing one.

Feedback welcome.