### PR TITLE
Add compare_NS and ccompare_NS.

### DIFF
--- a/src/Generics/SOP.hs
+++ b/src/Generics/SOP.hs
@@ -287,6 +287,11 @@ module Generics.SOP (
   , hcliftA'
   , hcliftA2'
   , hcliftA3'
+    -- ** Comparison
+  , compare_NS
+  , ccompare_NS
+  , compare_SOP
+  , ccompare_SOP
     -- ** Collapsing
   , CollapseTo
   , HCollapse(..)

--- a/src/Generics/SOP/NS.hs
+++ b/src/Generics/SOP/NS.hs
@@ -44,6 +44,8 @@ module Generics.SOP.NS
     -- * Comparison
   , compare_NS
   , ccompare_NS
+  , compare_SOP
+  , ccompare_SOP
     -- * Collapsing
   , collapse_NS
   , collapse_SOP
@@ -414,11 +416,27 @@ cliftA2'_NS = hcliftA2'
 
 -- * Comparison
 
+-- | Compare two sums with respect to the choice they
+-- are making.
+--
+-- A value that chooses the first option
+-- is considered smaller than one that chooses the second
+-- option.
+--
+-- If the choices are different, then either the first
+-- (if the first is smaller than the second)
+-- or the third (if the first is larger than the second)
+-- argument are called. If both choices are equal, then the
+-- second argument is called, which has access to the
+-- elements contained in the sums.
+--
+-- @since 0.3.2.0
+--
 compare_NS ::
      forall r f g xs .
-     r                             -- LT
-  -> (forall x . f x -> g x -> r)  -- EQ
-  -> r                             -- GT
+     r                             -- ^ what to do if first is smaller
+  -> (forall x . f x -> g x -> r)  -- ^ what to do if both are equal
+  -> r                             -- ^ what to do if first is larger
   -> NS f xs -> NS g xs
   -> r
 compare_NS lt eq gt = go
@@ -429,13 +447,17 @@ compare_NS lt eq gt = go
     go (S _)  (Z _)  = gt
     go (S xs) (S ys) = go xs ys
 
+-- | Constrained version of 'compare_NS'.
+--
+-- @since 0.3.2.0
+--
 ccompare_NS ::
      forall c proxy r f g xs .
      (All c xs)
   => proxy c
-  -> r                                    -- LT
-  -> (forall x . c x => f x -> g x -> r)  -- EQ
-  -> r                                    -- GT
+  -> r                                    -- ^ what to do if first is smaller
+  -> (forall x . c x => f x -> g x -> r)  -- ^ what to do if both are equal
+  -> r                                    -- ^ what to do if first is larger
   -> NS f xs -> NS g xs
   -> r
 ccompare_NS _ lt eq gt = go
@@ -445,6 +467,41 @@ ccompare_NS _ lt eq gt = go
     go (Z _)  (S _)  = lt
     go (S _)  (Z _)  = gt
     go (S xs) (S ys) = go xs ys
+
+-- | Compare two sums of products with respect to the
+-- choice in the sum they are making.
+--
+-- Only the sum structure is used for comparison.
+-- This is a small wrapper around 'ccompare_NS' for
+-- a common special case.
+--
+-- @since 0.3.2.0
+--
+compare_SOP ::
+     forall r f g xss .
+     r                                      -- ^ what to do if first is smaller
+  -> (forall xs . NP f xs -> NP g xs -> r)  -- ^ what to do if both are equal
+  -> r                                      -- ^ what to do if first is larger
+  -> SOP f xss -> SOP g xss
+  -> r
+compare_SOP lt eq gt (SOP xs) (SOP ys) =
+  compare_NS lt eq gt xs ys
+
+-- | Constrained version of 'compare_SOP'.
+--
+-- @since 0.3.2.0
+--
+ccompare_SOP ::
+     forall c proxy r f g xss .
+     (All2 c xss)
+  => proxy c
+  -> r                                      -- ^ what to do if first is smaller
+  -> (forall xs . NP f xs -> NP g xs -> r)  -- ^ what to do if both are equal
+  -> r                                      -- ^ what to do if first is larger
+  -> SOP f xss -> SOP g xss
+  -> r
+ccompare_SOP p lt eq gt (SOP xs) (SOP ys) =
+  ccompare_NS (allP p) lt eq gt xs ys
 
 -- * Collapsing
 

--- a/src/Generics/SOP/NS.hs
+++ b/src/Generics/SOP/NS.hs
@@ -41,6 +41,9 @@ module Generics.SOP.NS
   , cmap_SOP
     -- * Dealing with @'All' c@
   , cliftA2'_NS
+    -- * Comparison
+  , compare_NS
+  , ccompare_NS
     -- * Collapsing
   , collapse_NS
   , collapse_SOP
@@ -408,6 +411,40 @@ cmap_SOP = hcmap
 cliftA2'_NS :: All2 c xss => proxy c -> (forall xs. All c xs => f xs -> g xs -> h xs) -> NP f xss -> NS g xss -> NS h xss
 
 cliftA2'_NS = hcliftA2'
+
+-- * Comparison
+
+compare_NS ::
+     forall r f g xs .
+     r                             -- LT
+  -> (forall x . f x -> g x -> r)  -- EQ
+  -> r                             -- GT
+  -> NS f xs -> NS g xs
+  -> r
+compare_NS lt eq gt = go
+  where
+    go :: forall ys . NS f ys -> NS g ys -> r
+    go (Z x)  (Z y)  = eq x y
+    go (Z _)  (S _)  = lt
+    go (S _)  (Z _)  = gt
+    go (S xs) (S ys) = go xs ys
+
+ccompare_NS ::
+     forall c proxy r f g xs .
+     (All c xs)
+  => proxy c
+  -> r                                    -- LT
+  -> (forall x . c x => f x -> g x -> r)  -- EQ
+  -> r                                    -- GT
+  -> NS f xs -> NS g xs
+  -> r
+ccompare_NS _ lt eq gt = go
+  where
+    go :: forall ys . (All c ys) => NS f ys -> NS g ys -> r
+    go (Z x)  (Z y)  = eq x y
+    go (Z _)  (S _)  = lt
+    go (S _)  (Z _)  = gt
+    go (S xs) (S ys) = go xs ys
 
 -- * Collapsing
 

--- a/src/Generics/SOP/NS.hs
+++ b/src/Generics/SOP/NS.hs
@@ -495,9 +495,9 @@ ccompare_SOP ::
      forall c proxy r f g xss .
      (All2 c xss)
   => proxy c
-  -> r                                      -- ^ what to do if first is smaller
-  -> (forall xs . NP f xs -> NP g xs -> r)  -- ^ what to do if both are equal
-  -> r                                      -- ^ what to do if first is larger
+  -> r                                                  -- ^ what to do if first is smaller
+  -> (forall xs . All c xs => NP f xs -> NP g xs -> r)  -- ^ what to do if both are equal
+  -> r                                                  -- ^ what to do if first is larger
   -> SOP f xss -> SOP g xss
   -> r
 ccompare_SOP p lt eq gt (SOP xs) (SOP ys) =


### PR DESCRIPTION
These are another two useful functions. They can be used to implement things like generic equality and ordering, among others.

I think this pattern occurs often enough that it deserves its own function. I also want to avoid as much as possible that end users have to write functions that traverse the (linear) structure of sums and products manually. For example, I'm playing with a different internal representation in the compact-representation branch that would make this sort of stuff less efficient, but would still allow an efficient direct implementation of `ccompare_NS`.

Documentation still to be added.

Also no idea if SOP version and `hcompare` should be added.

This is how `ccompare_SOP` would probably look like:
```
ccompare_SOP ::
     forall c proxy r f g xss .
     (All2 c xss)
  => proxy c
  -> r
  -> (forall xs . All c xs => NP f xs -> NP g xs -> r)
  -> r
  -> SOP f xss -> SOP g xss
  -> r
ccompare_SOP p lt eq gt (SOP xs) (SOP ys) =
  ccompare_NS (allP p) lt eq gt xs ys
```
It's not difficult to expand by hand when needed, but having it for convenience might still be worth it.

For reference, here is how to define generic equality and comparison once we have `ccompare_SOP`:
```
geq :: (Generic a, All2 Eq (Code a)) => a -> a -> Bool
geq x y =
  ccompare_SOP
    (Proxy @Eq)
    False
    (\ x' y' -> and $ hcollapse $ hczipWith (Proxy @Eq) (mapIIK (==)) x' y')
    False
    (from x)
    (from y)

gcmp :: (Generic a, All2 Ord (Code a)) => a -> a -> Ordering
gcmp x y =
  ccompare_SOP
    (Proxy @Ord)
    LT
    (\ x' y' -> mconcat $ hcollapse $ hczipWith (Proxy @Ord) (mapIIK compare) x' y')
    GT
    (from x)
    (from y)
```

Another function that sometimes comes up is a simple "are two values constructed using the same constructor" question, which can be defined as:
```
sameCon :: (Generic a) => a -> a -> Bool
sameCon x y =
  compare_SOP
    False
    (\ _ _ -> True)
    False
    (from x)
    (from y)
```