### PR TITLE
Update the predefined Generic instance to the current base

### DIFF
--- a/src/Generics/SOP/Instances.hs
+++ b/src/Generics/SOP/Instances.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 #if __GLASGOW_HASKELL__ >= 800
@@ -188,7 +189,13 @@ deriveGeneric ''ConstrRep
 
 -- From Data.Fixed:
 deriveGeneric ''Fixed
--- TODO: What about empty types? E0, E1, ..., E12
+deriveGeneric ''E0
+deriveGeneric ''E1
+deriveGeneric ''E2
+deriveGeneric ''E3
+deriveGeneric ''E6
+deriveGeneric ''E9
+deriveGeneric ''E12
 
 -- From Data.Functor.Compose
 #if MIN_VERSION_base(4,9,0)
@@ -258,8 +265,7 @@ deriveGeneric ''Version
 
 -- From Data.Void:
 #if MIN_VERSION_base(4,8,0)
--- TODO: Another empty type
--- deriveGeneric ''Void -- new
+deriveGeneric ''Void -- new
 #endif
 
 -- From Foreign.C.Error:

--- a/src/Generics/SOP/Instances.hs
+++ b/src/Generics/SOP/Instances.hs
@@ -16,6 +16,15 @@
 --
 module Generics.SOP.Instances () where
 
+-- GHC versions and base versions:
+--
+-- 7.6.3:  4.6.0.1
+-- 7.8.3:  4.7.0.1
+-- 7.8.4:  4.7.0.2
+-- 7.10.3: 4.8.2.0
+-- 8.0.2:  4.9.1.0
+-- 8.2.1:  4.10.?.?
+
 import Control.Applicative -- new
 import Control.Arrow -- new
 import Control.Exception
@@ -25,8 +34,8 @@ import Data.Data
 import Data.Fixed
 #if MIN_VERSION_base(4,9,0)
 import Data.Functor.Compose -- new
-#endif
 import qualified Data.Functor.Const -- new
+#endif
 #if MIN_VERSION_base(4,8,0)
 import Data.Functor.Identity -- new
 #endif
@@ -131,7 +140,9 @@ deriveGeneric ''NonTermination
 deriveGeneric ''NestedAtomically
 deriveGeneric ''BlockedIndefinitelyOnMVar
 deriveGeneric ''BlockedIndefinitelyOnSTM
+#if MIN_VERSION_base(4,8,0)
 deriveGeneric ''AllocationLimitExceeded -- new
+#endif
 deriveGeneric ''Deadlock
 deriveGeneric ''NoMethodError
 deriveGeneric ''PatternMatchFail
@@ -139,7 +150,9 @@ deriveGeneric ''RecConError
 deriveGeneric ''RecSelError
 deriveGeneric ''RecUpdError
 deriveGeneric ''ErrorCall
+#if MIN_VERSION_base(4,9,0)
 deriveGeneric ''TypeError -- new
+#endif
 deriveGeneric ''MaskingState
 
 -- From Data.Char:
@@ -163,7 +176,9 @@ deriveGeneric ''Compose -- new
 #endif
 
 -- From Data.Functor.Const
+#if MIN_VERSION_base(4,9,0)
 deriveGeneric ''Data.Functor.Const.Const -- new
+#endif
 
 -- From Data.Functor.Identity
 #if MIN_VERSION_base(4,8,0)

--- a/src/Generics/SOP/Instances.hs
+++ b/src/Generics/SOP/Instances.hs
@@ -59,6 +59,26 @@ import Data.Void -- new
 #endif
 import Foreign.C.Error
 import Foreign.C.Types
+import GHC.Conc -- new
+#if MIN_VERSION_base(4,9,0)
+import GHC.ExecutionStack -- new
+#endif
+import GHC.Exts -- new
+import GHC.IO.Buffer -- new
+import GHC.IO.Device -- new
+import GHC.IO.Encoding -- new
+import GHC.IO.Encoding.Failure -- new
+import GHC.IO.Handle -- new
+#if MIN_VERSION_base(4,8,0)
+import GHC.RTS.Flags -- new
+#endif
+#if MIN_VERSION_base(4,9,0)
+import qualified GHC.Stack -- new
+#endif
+#if MIN_VERSION_base(4,8,0)
+import GHC.StaticPtr -- new
+#endif
+import GHC.Stats -- new
 import System.Console.GetOpt
 import System.Exit
 import System.IO
@@ -272,6 +292,71 @@ deriveGeneric ''CSUSeconds
 deriveGeneric ''CFloat
 deriveGeneric ''CDouble
 
+-- From GHC.Conc:
+deriveGeneric ''ThreadStatus -- new
+deriveGeneric ''BlockReason -- new
+
+-- From GHC.ExecutionStack:
+#if MIN_VERSION_base(4,9,0)
+deriveGeneric ''Location -- new
+deriveGeneric ''SrcLoc -- new
+#endif
+
+-- From GHC.Exts:
+#if MIN_VERSION_base(4,9,0)
+deriveGeneric ''RuntimeRep -- new
+deriveGeneric ''VecCount -- new
+deriveGeneric ''VecElem -- new
+#endif
+deriveGeneric ''SpecConstrAnnotation -- new
+
+-- From GHC.IO.Buffer:
+deriveGeneric ''Buffer -- new
+deriveGeneric ''BufferState -- new
+
+-- From GHC.IO.Device:
+deriveGeneric ''IODeviceType -- new
+
+-- From GHC.IO.Encoding:
+deriveGeneric ''BufferCodec -- new
+deriveGeneric ''CodingProgress -- new
+
+-- From GHC.IO.Encoding.Failure:
+deriveGeneric ''CodingFailureMode -- new
+
+-- From GHC.IO.Handle:
+deriveGeneric ''HandlePosn -- new
+
+-- From GHC.RTS.Flags:
+#if MIN_VERSION_base(4,8,0)
+deriveGeneric ''RTSFlags -- new
+deriveGeneric ''GiveGCStats -- new
+deriveGeneric ''GCFlags -- new
+deriveGeneric ''ConcFlags -- new
+deriveGeneric ''MiscFlags -- new
+deriveGeneric ''DebugFlags -- new
+deriveGeneric ''DoCostCentres -- new
+deriveGeneric ''CCFlags -- new
+deriveGeneric ''DoHeapProfile -- new
+deriveGeneric ''ProfFlags -- new
+deriveGeneric ''DoTrace -- new
+deriveGeneric ''TraceFlags -- new
+deriveGeneric ''TickyFlags -- new
+#endif
+
+-- From GHC.Stack:
+#if MIN_VERSION_base(4,9,0)
+deriveGeneric ''GHC.Stack.SrcLoc -- new
+#endif
+
+-- From GHC.StaticPtr:
+#if MIN_VERSION_base(4,8,0)
+deriveGeneric ''StaticPtrInfo -- new
+#endif
+
+-- From GHC.Stats:
+deriveGeneric ''GCStats -- new
+
 -- From System.Console.GetOpt:
 
 deriveGeneric ''ArgOrder
@@ -359,6 +444,9 @@ deriveGeneric ''Number
 -- Weak
 -- ReadP
 -- ReadPrec
+-- STM
+-- TVar
+-- Natural
 --
 -- Datatypes we cannot currently handle:
 --

--- a/src/Generics/SOP/Instances.hs
+++ b/src/Generics/SOP/Instances.hs
@@ -16,17 +16,38 @@
 --
 module Generics.SOP.Instances () where
 
+import Control.Applicative -- new
+import Control.Arrow -- new
 import Control.Exception
 import Data.Char
 import Data.Complex
 import Data.Data
 import Data.Fixed
-import Data.Monoid
+#if MIN_VERSION_base(4,9,0)
+import Data.Functor.Compose -- new
+#endif
+import qualified Data.Functor.Const -- new
+#if MIN_VERSION_base(4,8,0)
+import Data.Functor.Identity -- new
+#endif
+#if MIN_VERSION_base(4,9,0)
+import Data.Functor.Product -- new
+import Data.Functor.Sum -- new
+import Data.List.NonEmpty -- new
+#endif
+import qualified Data.Monoid
 import Data.Ord
 #if !(MIN_VERSION_base(4,7,0))
 import Data.Proxy
 #endif
+#if MIN_VERSION_base(4,9,0)
+import qualified Data.Semigroup -- new
+#endif
+import Data.Typeable.Internal -- new
 import Data.Version
+#if MIN_VERSION_base(4,8,0)
+import Data.Void -- new
+#endif
 import Foreign.C.Error
 import Foreign.C.Types
 import System.Console.GetOpt
@@ -91,6 +112,15 @@ deriveGeneric ''[]
 
 -- Other types from base:
 
+-- From Control.Applicative:
+deriveGeneric ''WrappedMonad -- new
+deriveGeneric ''WrappedArrow -- new
+deriveGeneric ''ZipList -- new
+
+-- From Control.Arrow:
+deriveGeneric ''Kleisli -- new
+deriveGeneric ''ArrowMonad -- new
+
 -- From Control.Exception:
 deriveGeneric ''IOException
 deriveGeneric ''ArithException
@@ -101,6 +131,7 @@ deriveGeneric ''NonTermination
 deriveGeneric ''NestedAtomically
 deriveGeneric ''BlockedIndefinitelyOnMVar
 deriveGeneric ''BlockedIndefinitelyOnSTM
+deriveGeneric ''AllocationLimitExceeded -- new
 deriveGeneric ''Deadlock
 deriveGeneric ''NoMethodError
 deriveGeneric ''PatternMatchFail
@@ -108,6 +139,7 @@ deriveGeneric ''RecConError
 deriveGeneric ''RecSelError
 deriveGeneric ''RecUpdError
 deriveGeneric ''ErrorCall
+deriveGeneric ''TypeError -- new
 deriveGeneric ''MaskingState
 
 -- From Data.Char:
@@ -123,16 +155,48 @@ deriveGeneric ''ConstrRep
 
 -- From Data.Fixed:
 deriveGeneric ''Fixed
+-- TODO: What about empty types? E0, E1, ..., E12
+
+-- From Data.Functor.Compose
+#if MIN_VERSION_base(4,9,0)
+deriveGeneric ''Compose -- new
+#endif
+
+-- From Data.Functor.Const
+deriveGeneric ''Data.Functor.Const.Const -- new
+
+-- From Data.Functor.Identity
+#if MIN_VERSION_base(4,8,0)
+deriveGeneric ''Identity -- new
+#endif
+
+-- From Data.Functor.Product
+#if MIN_VERSION_base(4,9,0)
+deriveGeneric ''Product -- new
+#endif
+
+-- From Data.Functor.Sum
+#if MIN_VERSION_base(4,9,0)
+deriveGeneric ''Sum -- new
+#endif
+
+-- From Data.List.NonEmpty
+#if MIN_VERSION_base(4,9,0)
+deriveGeneric ''NonEmpty -- new
+#endif
 
 -- From Data.Monoid:
-deriveGeneric ''Dual
-deriveGeneric ''Endo
-deriveGeneric ''All
-deriveGeneric ''Any
-deriveGeneric ''Sum
-deriveGeneric ''Product
-deriveGeneric ''First
-deriveGeneric ''Last
+deriveGeneric ''Data.Monoid.Dual
+deriveGeneric ''Data.Monoid.Endo
+deriveGeneric ''Data.Monoid.All
+deriveGeneric ''Data.Monoid.Any
+deriveGeneric ''Data.Monoid.Sum
+deriveGeneric ''Data.Monoid.Product
+deriveGeneric ''Data.Monoid.First
+deriveGeneric ''Data.Monoid.Last
+#if MIN_VERSION_base(4,8,0)
+deriveGeneric ''Data.Monoid.Alt -- new
+#endif
 
 -- From Data.Ord:
 deriveGeneric ''Down
@@ -140,8 +204,28 @@ deriveGeneric ''Down
 -- From Data.Proxy:
 deriveGeneric ''Proxy
 
+-- From Data.Semigroup:
+#if MIN_VERSION_base(4,9,0)
+deriveGeneric ''Data.Semigroup.Min -- new
+deriveGeneric ''Data.Semigroup.Max -- new
+deriveGeneric ''Data.Semigroup.First -- new
+deriveGeneric ''Data.Semigroup.Last -- new
+deriveGeneric ''Data.Semigroup.WrappedMonoid -- new
+deriveGeneric ''Data.Semigroup.Option -- new
+deriveGeneric ''Data.Semigroup.Arg -- new
+#endif
+
+-- From Data.Typeable.Internal
+deriveGeneric ''Fingerprint -- new
+
 -- From Data.Version:
 deriveGeneric ''Version
+
+-- From Data.Void:
+#if MIN_VERSION_base(4,8,0)
+-- TODO: Another empty type
+-- deriveGeneric ''Void -- new
+#endif
 
 -- From Foreign.C.Error:
 deriveGeneric ''Errno
@@ -217,6 +301,7 @@ deriveGeneric ''Number
 -- QSem
 -- QSemN
 -- DataType
+-- Constr
 -- Dynamic
 -- IORef
 -- TypeRep

--- a/src/Generics/SOP/Instances.hs
+++ b/src/Generics/SOP/Instances.hs
@@ -53,7 +53,6 @@ import Data.Proxy
 #if MIN_VERSION_base(4,9,0)
 import qualified Data.Semigroup -- new
 #endif
-import Data.Typeable.Internal -- new
 import Data.Version
 #if MIN_VERSION_base(4,8,0)
 import Data.Void -- new
@@ -65,6 +64,7 @@ import GHC.Conc -- new
 import GHC.ExecutionStack -- new
 #endif
 import GHC.Exts -- new
+import GHC.Fingerprint -- new
 import GHC.IO.Buffer -- new
 import GHC.IO.Device -- new
 import GHC.IO.Encoding -- new
@@ -257,9 +257,6 @@ deriveGeneric ''Data.Semigroup.Option -- new
 deriveGeneric ''Data.Semigroup.Arg -- new
 #endif
 
--- From Data.Typeable.Internal
-deriveGeneric ''Fingerprint -- new
-
 -- From Data.Version:
 deriveGeneric ''Version
 
@@ -329,6 +326,9 @@ deriveGeneric ''CodingProgress -- new
 
 -- From GHC.IO.Encoding.Failure:
 deriveGeneric ''CodingFailureMode -- new
+
+-- From GHC.Fingerprint
+deriveGeneric ''Fingerprint -- new
 
 -- From GHC.IO.Handle:
 deriveGeneric ''HandlePosn -- new


### PR DESCRIPTION
This adds `Generic` instances for quite a few new datatypes that have been added to base in the meantime. Does require a bit of CPP wrapping to distinguish the versions of base when instances have been added.

After discussing with @phadej, I think this can probably get away with a minor version bump, because we're only adding non-orphan instances.