### PR TITLE
Add Monoid instances for basic functors, NP, POP.

### DIFF
--- a/src/Generics/SOP/BasicFunctors.hs
+++ b/src/Generics/SOP/BasicFunctors.hs
@@ -48,7 +48,7 @@ import Data.Monoid ((<>))
 #else
 import Control.Applicative
 import Data.Foldable (Foldable(..))
-import Data.Monoid (Monoid, mempty, (<>))
+import Data.Monoid (Monoid(..), (<>))
 import Data.Traversable (Traversable(..))
 #endif
 import qualified GHC.Generics as GHC
@@ -155,6 +155,10 @@ instance (Show a) => Show (K a b) where
     showsPrec d (K x) = showsUnary "K" d x
 #endif
 
+instance Monoid a => Monoid (K a b) where
+  mempty              = K mempty
+  mappend (K x) (K y) = K (mappend x y)
+
 instance Monoid a => Applicative (K a) where
   pure _      = K mempty
   K x <*> K y = K (x <> y)
@@ -183,6 +187,10 @@ instance Foldable I where
 instance Traversable I where
   traverse f (I x) = fmap I (f x)
 #endif
+
+instance Monoid a => Monoid (I a) where
+  mempty              = I mempty
+  mappend (I x) (I y) = I (mappend x y)
 
 instance Applicative I where
   pure = I
@@ -240,6 +248,10 @@ newtype (:.:) (f :: l -> *) (g :: k -> l) (p :: k) = Comp (f (g p))
   deriving (GHC.Generic)
 
 infixr 7 :.:
+
+instance (Monoid (f (g x))) => Monoid ((f :.: g) x) where
+  mempty                    = Comp mempty
+  mappend (Comp x) (Comp y) = Comp (mappend x y)
 
 instance (Functor f, Functor g) => Functor (f :.: g) where
   fmap f (Comp x) = Comp (fmap (fmap f) x)

--- a/src/Generics/SOP/NP.hs
+++ b/src/Generics/SOP/NP.hs
@@ -77,6 +77,7 @@ module Generics.SOP.NP
 
 #if !(MIN_VERSION_base(4,8,0))
 import Control.Applicative
+import Data.Monoid (Monoid(..))
 #endif
 import Data.Coerce
 import Data.Proxy (Proxy(..))
@@ -127,6 +128,10 @@ deriving instance All (Show `Compose` f) xs => Show (NP f xs)
 deriving instance All (Eq   `Compose` f) xs => Eq   (NP f xs)
 deriving instance (All (Eq `Compose` f) xs, All (Ord `Compose` f) xs) => Ord (NP f xs)
 
+instance All (Monoid `Compose` f) xs => Monoid (NP f xs) where
+  mempty  = cpure_NP (Proxy :: Proxy (Monoid `Compose` f)) mempty
+  mappend = czipWith_NP (Proxy :: Proxy (Monoid `Compose` f)) mappend
+
 -- | @since 0.2.5.0
 instance All (NFData `Compose` f) xs => NFData (NP f xs) where
     rnf Nil       = ()
@@ -151,6 +156,10 @@ newtype POP (f :: (k -> *)) (xss :: [[k]]) = POP (NP (NP f) xss)
 deriving instance (Show (NP (NP f) xss)) => Show (POP f xss)
 deriving instance (Eq   (NP (NP f) xss)) => Eq   (POP f xss)
 deriving instance (Ord  (NP (NP f) xss)) => Ord  (POP f xss)
+
+instance (Monoid (NP (NP f) xss)) => Monoid (POP f xss) where
+  mempty                      = POP mempty
+  mappend (POP xss) (POP yss) = POP (mappend xss yss)
 
 -- | @since 0.2.5.0
 instance (NFData (NP (NP f) xss)) => NFData (POP f xss) where


### PR DESCRIPTION
Inspired by https://stackoverflow.com/a/45523136/1482749

Still needs since-annotations before it can be merged, but it otherwise doesn't seem very controversial to me.

/cc @phadej @danidiaz