### PR TITLE
Adapt to GHC 8.6 'StarIsType' changes

### DIFF
--- a/src/Generics/SOP/BasicFunctors.hs
+++ b/src/Generics/SOP/BasicFunctors.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE PolyKinds, DeriveGeneric #-}
+#if __GLASGOW_HASKELL__ >= 805
+{-# LANGUAGE StarIsType #-}
+#endif
 -- | Basic functors.
 --
 -- Definitions of the type-level equivalents of

--- a/src/Generics/SOP/Classes.hs
+++ b/src/Generics/SOP/Classes.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE PolyKinds #-}
+#if __GLASGOW_HASKELL__ >= 805
+{-# LANGUAGE StarIsType #-}
+#endif
 -- | Classes for generalized combinators on SOP types.
 --
 -- In the SOP approach to generic programming, we're predominantly

--- a/src/Generics/SOP/Constraint.hs
+++ b/src/Generics/SOP/Constraint.hs
@@ -5,6 +5,9 @@
 #if __GLASGOW_HASKELL__ >= 800
 {-# LANGUAGE UndecidableSuperClasses #-}
 #endif
+#if __GLASGOW_HASKELL__ >= 805
+{-# LANGUAGE StarIsType #-}
+#endif
 {-# OPTIONS_GHC -fno-warn-orphans -fno-warn-deprecations #-}
 -- | Constraints for indexed datatypes.
 --

--- a/src/Generics/SOP/GGP.hs
+++ b/src/Generics/SOP/GGP.hs
@@ -2,6 +2,9 @@
 #if __GLASGOW_HASKELL__ >= 780
 {-# OPTIONS_GHC -fno-warn-unticked-promoted-constructors #-}
 #endif
+#if __GLASGOW_HASKELL__ >= 805
+{-# LANGUAGE StarIsType #-}
+#endif
 -- | Derive @generics-sop@ boilerplate instances from GHC's 'GHC.Generic'.
 --
 -- The technique being used here is described in the following paper:

--- a/src/Generics/SOP/Metadata.hs
+++ b/src/Generics/SOP/Metadata.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE StandaloneDeriving, UndecidableInstances #-}
+#if __GLASGOW_HASKELL__ >= 805
+{-# LANGUAGE StarIsType #-}
+#endif
 -- | Metadata about what a datatype looks like
 --
 -- In @generics-sop@, the metadata is completely independent of the main

--- a/src/Generics/SOP/NP.hs
+++ b/src/Generics/SOP/NP.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE PolyKinds, StandaloneDeriving, UndecidableInstances #-}
+#if __GLASGOW_HASKELL__ >= 805
+{-# LANGUAGE StarIsType #-}
+#endif
 -- | n-ary products (and products of products)
 module Generics.SOP.NP
   ( -- * Datatypes

--- a/src/Generics/SOP/NS.hs
+++ b/src/Generics/SOP/NS.hs
@@ -3,6 +3,9 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
+#if __GLASGOW_HASKELL__ >= 805
+{-# LANGUAGE StarIsType #-}
+#endif
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
 -- | n-ary sums (and sums of products)
 module Generics.SOP.NS

--- a/src/Generics/SOP/Sing.hs
+++ b/src/Generics/SOP/Sing.hs
@@ -2,6 +2,9 @@
 #if MIN_VERSION_base(4,7,0)
 {-# LANGUAGE NoAutoDeriveTypeable #-}
 #endif
+#if __GLASGOW_HASKELL__ >= 805
+{-# LANGUAGE StarIsType #-}
+#endif
 -- | Singleton types corresponding to type-level data structures.
 --
 -- The implementation is similar, but subtly different to that of the

--- a/src/Generics/SOP/Type/Metadata.hs
+++ b/src/Generics/SOP/Type/Metadata.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE PolyKinds, UndecidableInstances #-}
+#if __GLASGOW_HASKELL__ >= 805
+{-# LANGUAGE StarIsType #-}
+#endif
 -- | Type-level metadata
 --
 -- This module provides datatypes (to be used promoted) that can represent the

--- a/src/Generics/SOP/Universe.hs
+++ b/src/Generics/SOP/Universe.hs
@@ -2,6 +2,9 @@
 #if __GLASGOW_HASKELL__ >= 800
 {-# LANGUAGE UndecidableSuperClasses #-}
 #endif
+#if __GLASGOW_HASKELL__ >= 805
+{-# LANGUAGE StarIsType #-}
+#endif
 -- | Codes and interpretations
 module Generics.SOP.Universe where
 


### PR DESCRIPTION
Starting in 8.6, GHC does not accept `*` as a kind annotation unless
`StarIsType` is enabled. It would obviously be preferable to switch all
uses of `*` to `Type`, but that would break builds on < 8.0.

See https://ghc.haskell.org/trac/ghc/wiki/Migration/8.6#StarIsType