### PR TITLE
Generic generic

### DIFF
--- a/src/Generics/SOP/Universe.hs
+++ b/src/Generics/SOP/Universe.hs
@@ -128,6 +128,11 @@ class (All SListI (Code a)) => Generic (a :: *) where
              => Rep a -> a
   to = gto
 
+instance All SListI a => Generic (SOP I a) where
+  type Code (SOP I a) = a
+  from = id
+  to = id
+
 -- | A class of datatypes that have associated metadata.
 --
 -- It is possible to use the sum-of-products approach to generic programming


### PR DESCRIPTION
The reason this is useful is to be able to combine `Rep`s of different types, and pretend that they are actually a `Generic` type on their own.