### PR TITLE
Remove most uses of 'error' using EmptyCase

### DIFF
--- a/src/Generics/SOP/GGP.hs
+++ b/src/Generics/SOP/GGP.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE EmptyCase, LambdaCase, PolyKinds, UndecidableInstances #-}
+{-# LANGUAGE EmptyCase, PolyKinds, UndecidableInstances #-}
 #if __GLASGOW_HASKELL__ >= 780
 {-# OPTIONS_GHC -fno-warn-unticked-promoted-constructors #-}
 #endif
@@ -294,7 +294,7 @@ gfrom x = gSumFrom (GHC.from x) (error "gfrom: internal error" :: SOP.SOP SOP.I 
 -- For more info, see 'Generics.SOP.Generic'.
 --
 gto :: forall a. (GTo a, GHC.Generic a) => SOP I (GCode a) -> a
-gto x = GHC.to (gSumTo x id (\case :: SOP I '[] -> (GHC.Rep a) x))
+gto x = GHC.to (gSumTo x id ((\y -> case y of {}) :: SOP I '[] -> (GHC.Rep a) x))
 
 -- | An automatically computed version of 'Generics.SOP.datatypeInfo'.
 --

--- a/src/Generics/SOP/GGP.hs
+++ b/src/Generics/SOP/GGP.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE PolyKinds, UndecidableInstances #-}
+{-# LANGUAGE EmptyCase, LambdaCase, PolyKinds, UndecidableInstances #-}
 #if __GLASGOW_HASKELL__ >= 780
 {-# OPTIONS_GHC -fno-warn-unticked-promoted-constructors #-}
 #endif
@@ -210,7 +210,7 @@ class GSumFrom (a :: * -> *) where
   gSumSkip :: proxy a -> SOP I xss -> SOP I (ToSumCode a xss)
 
 instance GSumFrom V1 where
-  gSumFrom x = x `seq` error "GSumFrom V1"
+  gSumFrom x = case x of {}
   gSumSkip _ xss = xss
 
 instance (GSumFrom a, GSumFrom b) => GSumFrom (a :+: b) where
@@ -294,7 +294,7 @@ gfrom x = gSumFrom (GHC.from x) (error "gfrom: internal error" :: SOP.SOP SOP.I 
 -- For more info, see 'Generics.SOP.Generic'.
 --
 gto :: forall a. (GTo a, GHC.Generic a) => SOP I (GCode a) -> a
-gto x = GHC.to (gSumTo x id ((\ _ -> error "inaccessible") :: SOP I '[] -> (GHC.Rep a) x))
+gto x = GHC.to (gSumTo x id (\case :: SOP I '[] -> (GHC.Rep a) x))
 
 -- | An automatically computed version of 'Generics.SOP.datatypeInfo'.
 --

--- a/src/Generics/SOP/Instances.hs
+++ b/src/Generics/SOP/Instances.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 #if __GLASGOW_HASKELL__ >= 800

--- a/src/Generics/SOP/Instances.hs
+++ b/src/Generics/SOP/Instances.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 #if __GLASGOW_HASKELL__ >= 800

--- a/src/Generics/SOP/NS.hs
+++ b/src/Generics/SOP/NS.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -172,7 +173,7 @@ instance All (NFData `Compose` f) xs => NFData (NS f xs) where
 --
 unZ :: NS f '[x] -> f x
 unZ (Z x) = x
-unZ _     = error "inaccessible" -- needed even in GHC 8.0.1
+unZ (S x) = case x of {}
 
 -- | Obtain the index from an n-ary sum.
 --
@@ -357,7 +358,7 @@ instance HApInjs SOP where
 ap_NS :: NP (f -.-> g) xs -> NS f xs -> NS g xs
 ap_NS (Fn f  :* _)   (Z x)   = Z (f x)
 ap_NS (_     :* fs)  (S xs)  = S (ap_NS fs xs)
-ap_NS _ _ = error "inaccessible"
+ap_NS Nil            x       = case x of {}
 
 -- | Specialization of 'hap'.
 ap_SOP  :: POP (f -.-> g) xss -> SOP f xss -> SOP g xss
@@ -366,7 +367,7 @@ ap_SOP (POP fss') (SOP xss') = SOP (go fss' xss')
     go :: NP (NP (f -.-> g)) xss -> NS (NP f) xss -> NS (NP g) xss
     go (fs :* _  ) (Z xs ) = Z (ap_NP fs  xs )
     go (_  :* fss) (S xss) = S (go    fss xss)
-    go _           _       = error "inaccessible"
+    go Nil         x       = case x of {}
 
 -- The definition of 'ap_SOP' is a more direct variant of
 -- '_ap_SOP_spec'. The direct definition has the advantage
@@ -812,7 +813,7 @@ expand_NS d = go sList
     go :: forall ys . SList ys -> NS f ys -> NP f ys
     go SCons (Z x) = x :* hpure d
     go SCons (S i) = d :* go sList i
-    go SNil  _     = error "inaccessible" -- still required in ghc-8.0.*
+    go SNil  x     = case x of {}
 
 -- | Specialization of 'hcexpand'.
 --

--- a/src/Generics/SOP/TH.hs
+++ b/src/Generics/SOP/TH.hs
@@ -29,9 +29,8 @@ import Generics.SOP.Universe
 --   * a 'Generic' instance
 --   * a 'HasDatatypeInfo' instance
 --
--- Note that the generated code will require the @TypeFamilies@,
--- @DataKinds@, and @EmptyCase@ extensions to be enabled for the
--- module.
+-- Note that the generated code will require the @TypeFamilies@ and
+-- @DataKinds@ extensions to be enabled for the module.
 --
 -- /Example:/ If you have the datatype
 --


### PR DESCRIPTION
Despite having lots of fancy types at its disposal, `generics-sop` bails out to `error` clauses in several places, which feels silly. This removes as many `error` cases as possible using the `EmptyCase` extension, which has the benefit of making several functions actually total.

This is a bit of a breaking change in that the TH-generated code now requires the `EmptyCase` extension. If this is a step too far, I could revert that part and only submit the remaining patch (since the rest of it does not constitute a breaking change by itself).

Fixes #57.