### PR TITLE
Use Type instead of *

### DIFF
--- a/generics-sop/generics-sop.cabal
+++ b/generics-sop/generics-sop.cabal
@@ -86,6 +86,8 @@ library
                        DataKinds
                        FunctionalDependencies
                        AutoDeriveTypeable
+  if impl(ghc >= 8.6)
+    default-extensions: NoStarIsType
   other-extensions:    PolyKinds
                        UndecidableInstances
                        TemplateHaskell

--- a/generics-sop/src/Generics/SOP/GGP.hs
+++ b/generics-sop/src/Generics/SOP/GGP.hs
@@ -19,7 +19,8 @@ module Generics.SOP.GGP
   , gdatatypeInfo
   ) where
 
-import Data.Proxy
+import Data.Proxy (Proxy (..))
+import Data.Kind (Type)
 import GHC.Generics as GHC
 import Generics.SOP.NP as SOP
 import Generics.SOP.NS as SOP
@@ -27,34 +28,34 @@ import Generics.SOP.BasicFunctors as SOP
 import qualified Generics.SOP.Type.Metadata as SOP.T
 import Generics.SOP.Metadata as SOP
 
-type family ToSingleCode (a :: * -> *) :: *
+type family ToSingleCode (a :: Type -> Type) :: Type
 type instance ToSingleCode (K1 _i a) = a
 
-type family ToProductCode (a :: * -> *) (xs :: [*]) :: [*]
+type family ToProductCode (a :: Type -> Type) (xs :: [Type]) :: [Type]
 type instance ToProductCode (a :*: b)   xs = ToProductCode a (ToProductCode b xs)
 type instance ToProductCode U1          xs = xs
 type instance ToProductCode (M1 S _c a) xs = ToSingleCode a ': xs
 
-type family ToSumCode (a :: * -> *) (xs :: [[*]]) :: [[*]]
+type family ToSumCode (a :: Type -> Type) (xs :: [[Type]]) :: [[Type]]
 type instance ToSumCode (a :+: b)   xs = ToSumCode a (ToSumCode b xs)
 type instance ToSumCode V1          xs = xs
 type instance ToSumCode (M1 D _c a) xs = ToSumCode a xs
 type instance ToSumCode (M1 C _c a) xs = ToProductCode a '[] ': xs
 
-data InfoProxy (c :: Meta) (f :: * -> *) (x :: *) = InfoProxy
+data InfoProxy (c :: Meta) (f :: Type -> Type) (x :: Type) = InfoProxy
 
-type family ToInfo (a :: * -> *) :: SOP.T.DatatypeInfo
+type family ToInfo (a :: Type -> Type) :: SOP.T.DatatypeInfo
 type instance ToInfo (M1 D (MetaData n m p False) a) =
   SOP.T.ADT m n (ToSumInfo a '[])
 type instance ToInfo (M1 D (MetaData n m p True) a) =
   SOP.T.Newtype m n (ToSingleConstructorInfo a)
 
-type family ToSumInfo (a :: * -> *) (xs :: [SOP.T.ConstructorInfo]) :: [SOP.T.ConstructorInfo]
+type family ToSumInfo (a :: Type -> Type) (xs :: [SOP.T.ConstructorInfo]) :: [SOP.T.ConstructorInfo]
 type instance ToSumInfo (a :+: b)  xs = ToSumInfo a (ToSumInfo b xs)
 type instance ToSumInfo V1         xs = xs
 type instance ToSumInfo (M1 C c a) xs = ToSingleConstructorInfo (M1 C c a) ': xs
 
-type family ToSingleConstructorInfo (a :: * -> *) :: SOP.T.ConstructorInfo
+type family ToSingleConstructorInfo (a :: Type -> Type) :: SOP.T.ConstructorInfo
 type instance ToSingleConstructorInfo (M1 C (MetaCons n PrefixI False) a) =
   SOP.T.Constructor n
 type instance ToSingleConstructorInfo (M1 C (MetaCons n (InfixI assoc fix) False) a) =
@@ -62,15 +63,15 @@ type instance ToSingleConstructorInfo (M1 C (MetaCons n (InfixI assoc fix) False
 type instance ToSingleConstructorInfo (M1 C (MetaCons n f True) a) =
   SOP.T.Record n (ToProductInfo a '[])
 
-type family ToProductInfo (a :: * -> *) (xs :: [SOP.T.FieldInfo]) :: [SOP.T.FieldInfo]
+type family ToProductInfo (a :: Type -> Type) (xs :: [SOP.T.FieldInfo]) :: [SOP.T.FieldInfo]
 type instance ToProductInfo (a :*: b)  xs = ToProductInfo a (ToProductInfo b xs)
 type instance ToProductInfo U1         xs = xs
 type instance ToProductInfo (M1 S c a) xs = ToSingleInfo (M1 S c a) ': xs
 
-type family ToSingleInfo (a :: * -> *) :: SOP.T.FieldInfo
+type family ToSingleInfo (a :: Type -> Type) :: SOP.T.FieldInfo
 type instance ToSingleInfo (M1 S (MetaSel (Just n) _su _ss _ds) a) = 'SOP.T.FieldInfo n
 
-class GFieldInfos (a :: * -> *) where
+class GFieldInfos (a :: Type -> Type) where
   gFieldInfos :: proxy a -> NP FieldInfo xs -> NP FieldInfo (ToProductCode a xs)
 
 instance (GFieldInfos a, GFieldInfos b) => GFieldInfos (a :*: b) where
@@ -85,13 +86,13 @@ instance (Selector c) => GFieldInfos (M1 S c a) where
       p :: InfoProxy c a x
       p = InfoProxy
 
-class GSingleFrom (a :: * -> *) where
+class GSingleFrom (a :: Type -> Type) where
   gSingleFrom :: a x -> ToSingleCode a
 
 instance GSingleFrom (K1 i a) where
   gSingleFrom (K1 a) = a
 
-class GProductFrom (a :: * -> *) where
+class GProductFrom (a :: Type -> Type) where
   gProductFrom :: a x -> NP I xs -> NP I (ToProductCode a xs)
 
 instance (GProductFrom a, GProductFrom b) => GProductFrom (a :*: b) where
@@ -103,13 +104,13 @@ instance GProductFrom U1 where
 instance GSingleFrom a => GProductFrom (M1 S c a) where
   gProductFrom (M1 a) xs = I (gSingleFrom a) :* xs
 
-class GSingleTo (a :: * -> *) where
+class GSingleTo (a :: Type -> Type) where
   gSingleTo :: ToSingleCode a -> a x
 
 instance GSingleTo (K1 i a) where
   gSingleTo a = K1 a
 
-class GProductTo (a :: * -> *) where
+class GProductTo (a :: Type -> Type) where
   gProductTo :: NP I (ToProductCode a xs) -> (a x -> NP I xs -> r) -> r
 
 instance (GProductTo a, GProductTo b) => GProductTo (a :*: b) where
@@ -122,7 +123,7 @@ instance GProductTo U1 where
   gProductTo xs k = k U1 xs
 
 -- This can most certainly be simplified
-class GSumFrom (a :: * -> *) where
+class GSumFrom (a :: Type -> Type) where
   gSumFrom :: a x -> SOP I xss -> SOP I (ToSumCode a xss)
   gSumSkip :: proxy a -> SOP I xss -> SOP I (ToSumCode a xss)
 
@@ -144,7 +145,7 @@ instance (GProductFrom a) => GSumFrom (M1 C c a) where
   gSumFrom (M1 a) _    = SOP (Z (gProductFrom a Nil))
   gSumSkip _ (SOP xss) = SOP (S xss)
 
-class GSumTo (a :: * -> *) where
+class GSumTo (a :: Type -> Type) where
   gSumTo :: SOP I (ToSumCode a xss) -> (a x -> r) -> (SOP I xss -> r) -> r
 
 instance GSumTo V1 where
@@ -168,7 +169,7 @@ instance (GSumTo a) => GSumTo (M1 D c a) where
 -- This is the default definition for 'Generics.SOP.Code'.
 -- For more info, see 'Generics.SOP.Generic'.
 --
-type GCode (a :: *) = ToSumCode (GHC.Rep a) '[]
+type GCode (a :: Type) = ToSumCode (GHC.Rep a) '[]
 
 -- | Constraint for the class that computes 'gfrom'.
 type GFrom a = GSumFrom (GHC.Rep a)
@@ -183,7 +184,7 @@ type GDatatypeInfo a = SOP.T.DemoteDatatypeInfo (GDatatypeInfoOf a) (GCode a)
 --
 -- @since 0.3.0.0
 --
-type GDatatypeInfoOf (a :: *) = ToInfo (GHC.Rep a)
+type GDatatypeInfoOf (a :: Type) = ToInfo (GHC.Rep a)
 
 -- | An automatically computed version of 'Generics.SOP.from'.
 --

--- a/generics-sop/src/Generics/SOP/Metadata.hs
+++ b/generics-sop/src/Generics/SOP/Metadata.hs
@@ -17,6 +17,7 @@ module Generics.SOP.Metadata
   , Associativity(..)
   ) where
 
+import Data.Kind (Type)
 import GHC.Generics (Associativity(..))
 
 import Generics.SOP.Constraint
@@ -33,7 +34,7 @@ import Generics.SOP.Sing
 -- The constructor indicates whether the datatype has been declared using @newtype@
 -- or not.
 --
-data DatatypeInfo :: [[*]] -> * where
+data DatatypeInfo :: [[Type]] -> Type where
   -- Standard algebraic datatype
   ADT     :: ModuleName -> DatatypeName -> NP ConstructorInfo xss -> DatatypeInfo xss
   -- Newtype
@@ -71,7 +72,7 @@ deriving instance (All (Eq `Compose` ConstructorInfo) xs, All (Ord `Compose` Con
 --
 -- This is indexed by the product structure of the constructor components.
 --
-data ConstructorInfo :: [*] -> * where
+data ConstructorInfo :: [Type] -> Type where
   -- Normal constructor
   Constructor :: SListI xs => ConstructorName -> ConstructorInfo xs
   -- Infix constructor
@@ -93,7 +94,7 @@ deriving instance All (Eq   `Compose` FieldInfo) xs => Eq   (ConstructorInfo xs)
 deriving instance (All (Eq `Compose` FieldInfo) xs, All (Ord `Compose` FieldInfo) xs) => Ord (ConstructorInfo xs)
 
 -- | For records, this functor maps the component to its selector name.
-data FieldInfo :: * -> * where
+data FieldInfo :: Type -> Type where
   FieldInfo :: FieldName -> FieldInfo a
   deriving (Show, Eq, Ord, Functor)
 

--- a/generics-sop/src/Generics/SOP/Type/Metadata.hs
+++ b/generics-sop/src/Generics/SOP/Type/Metadata.hs
@@ -31,7 +31,8 @@ module Generics.SOP.Type.Metadata
   , Associativity(..)
   ) where
 
-import Data.Proxy
+import Data.Kind (Type)
+import Data.Proxy (Proxy (..))
 import GHC.Generics (Associativity(..))
 import GHC.Types
 import GHC.TypeLits
@@ -108,7 +109,7 @@ type Fixity          = Nat
 --
 -- @since 0.3.0.0
 --
-class DemoteDatatypeInfo (x :: DatatypeInfo) (xss :: [[*]]) where
+class DemoteDatatypeInfo (x :: DatatypeInfo) (xss :: [[Type]]) where
   -- | Given a proxy of some type-level datatype information,
   -- return the corresponding term-level information.
   --
@@ -139,7 +140,7 @@ instance
 --
 -- @since 0.3.0.0
 --
-class DemoteConstructorInfos (cs :: [ConstructorInfo]) (xss :: [[*]]) where
+class DemoteConstructorInfos (cs :: [ConstructorInfo]) (xss :: [[Type]]) where
   -- | Given a proxy of some type-level constructor information,
   -- return the corresponding term-level information as a product.
   --
@@ -161,7 +162,7 @@ instance
 --
 -- @since 0.3.0.0
 --
-class DemoteConstructorInfo (x :: ConstructorInfo) (xs :: [*]) where
+class DemoteConstructorInfo (x :: ConstructorInfo) (xs :: [Type]) where
   -- | Given a proxy of some type-level constructor information,
   -- return the corresponding term-level information.
   --
@@ -190,7 +191,7 @@ instance (KnownSymbol s, DemoteFieldInfos fs xs) => DemoteConstructorInfo ('Reco
 --
 -- @since 0.3.0.0
 --
-class SListI xs => DemoteFieldInfos (fs :: [FieldInfo]) (xs :: [*]) where
+class SListI xs => DemoteFieldInfos (fs :: [FieldInfo]) (xs :: [Type]) where
   -- | Given a proxy of some type-level field information,
   -- return the corresponding term-level information as a product.
   --
@@ -211,7 +212,7 @@ instance
 --
 -- @since 0.3.0.0
 --
-class DemoteFieldInfo (x :: FieldInfo) (a :: *) where
+class DemoteFieldInfo (x :: FieldInfo) (a :: Type) where
   -- | Given a proxy of some type-level field information,
   -- return the corresponding term-level information.
   --

--- a/generics-sop/src/Generics/SOP/Universe.hs
+++ b/generics-sop/src/Generics/SOP/Universe.hs
@@ -3,6 +3,7 @@
 -- | Codes and interpretations
 module Generics.SOP.Universe where
 
+import Data.Kind (Type)
 import Data.Coerce (Coercible)
 import qualified GHC.Generics as GHC
 
@@ -92,7 +93,7 @@ type Rep a = SOP I (Code a)
 --
 -- still holds.
 --
-class (All SListI (Code a)) => Generic (a :: *) where
+class (All SListI (Code a)) => Generic (a :: Type) where
   -- | The code of a datatype.
   --
   -- This is a list of lists of its components. The outer list contains
@@ -110,7 +111,7 @@ class (All SListI (Code a)) => Generic (a :: *) where
   -- >    , '[ Tree, Tree ]
   -- >    ]
   --
-  type Code a :: [[*]]
+  type Code a :: [[Type]]
   type Code a = GCode a
 
   -- | Converts from a value to its structural representation.
@@ -156,7 +157,7 @@ class HasDatatypeInfo a where
 --
 -- @since 0.3.1.0
 --
-type IsProductType (a :: *) (xs :: [*]) =
+type IsProductType (a :: Type) (xs :: [Type]) =
   (Generic a, Code a ~ '[ xs ])
 
 -- | Constraint that captures that a datatype is an enumeration type,
@@ -164,7 +165,7 @@ type IsProductType (a :: *) (xs :: [*]) =
 --
 -- @since 0.3.1.0
 --
-type IsEnumType (a :: *) =
+type IsEnumType (a :: Type) =
   (Generic a, All ((~) '[]) (Code a))
 
 -- | Constraint that captures that a datatype is a single-constructor,
@@ -175,7 +176,7 @@ type IsEnumType (a :: *) =
 --
 -- @since 0.3.1.0
 --
-type IsWrappedType (a :: *) (x :: *) =
+type IsWrappedType (a :: Type) (x :: Type) =
   (Generic a, Code a ~ '[ '[ x ] ])
 
 -- | Constraint that captures that a datatype is a newtype.
@@ -184,5 +185,5 @@ type IsWrappedType (a :: *) (x :: *) =
 --
 -- @since 0.3.1.0
 --
-type IsNewtype (a :: *) (x :: *) =
+type IsNewtype (a :: Type) (x :: Type) =
   (IsWrappedType a x, Coercible a x)

--- a/sop-core/sop-core.cabal
+++ b/sop-core/sop-core.cabal
@@ -67,6 +67,8 @@ library
                        DataKinds
                        FunctionalDependencies
                        AutoDeriveTypeable
+  if impl(ghc >= 8.6)
+    default-extensions: NoStarIsType
   other-extensions:    PolyKinds
                        UndecidableInstances
                        DeriveGeneric

--- a/sop-core/src/Data/SOP/BasicFunctors.hs
+++ b/sop-core/src/Data/SOP/BasicFunctors.hs
@@ -44,6 +44,7 @@ module Data.SOP.BasicFunctors
   ) where
 
 import Data.Semigroup (Semigroup (..))
+import Data.Kind (Type)
 import qualified GHC.Generics as GHC
 
 import Data.Functor.Classes
@@ -60,7 +61,7 @@ import Control.DeepSeq (NFData1(..), NFData2(..))
 -- Like 'Data.Functor.Constant.Constant', but kind-polymorphic
 -- in its second argument and with a shorter name.
 --
-newtype K (a :: *) (b :: k) = K a
+newtype K (a :: Type) (b :: k) = K a
   deriving (Functor, Foldable, Traversable, GHC.Generic)
 
 -- | @since 0.2.4.0
@@ -119,7 +120,7 @@ unK (K x) = x
 --
 -- Like 'Data.Functor.Identity.Identity', but with a shorter name.
 --
-newtype I (a :: *) = I a
+newtype I (a :: Type) = I a
   deriving (Functor, Foldable, Traversable, GHC.Generic)
 
 instance Semigroup a => Semigroup (I a) where
@@ -166,7 +167,7 @@ unI (I x) = x
 -- Like 'Data.Functor.Compose.Compose', but kind-polymorphic
 -- and with a shorter name.
 --
-newtype (:.:) (f :: l -> *) (g :: k -> l) (p :: k) = Comp (f (g p))
+newtype (:.:) (f :: l -> Type) (g :: k -> l) (p :: k) = Comp (f (g p))
   deriving (GHC.Generic)
 
 infixr 7 :.:

--- a/sop-core/src/Data/SOP/Classes.hs
+++ b/sop-core/src/Data/SOP/Classes.hs
@@ -5,16 +5,16 @@
 -- concerned with four structured datatypes:
 --
 -- @
---   'Data.SOP.NP.NP'  :: (k -> *) -> ( [k]  -> *)   -- n-ary product
---   'Data.SOP.NS.NS'  :: (k -> *) -> ( [k]  -> *)   -- n-ary sum
---   'Data.SOP.NP.POP' :: (k -> *) -> ([[k]] -> *)   -- product of products
---   'Data.SOP.NS.SOP' :: (k -> *) -> ([[k]] -> *)   -- sum of products
+--   'Data.SOP.NP.NP'  :: (k -> Type) -> ( [k]  -> Type)   -- n-ary product
+--   'Data.SOP.NS.NS'  :: (k -> Type) -> ( [k]  -> Type)   -- n-ary sum
+--   'Data.SOP.NP.POP' :: (k -> Type) -> ([[k]] -> Type)   -- product of products
+--   'Data.SOP.NS.SOP' :: (k -> Type) -> ([[k]] -> Type)   -- sum of products
 -- @
 --
 -- All of these have a kind that fits the following pattern:
 --
 -- @
---   (k -> *) -> (l -> *)
+--   (k -> Type) -> (l -> Type)
 -- @
 --
 -- These four types support similar interfaces. In order to allow
@@ -23,7 +23,7 @@
 -- generalization.
 --
 -- The classes typically lift concepts that exist for kinds @*@ or
--- @* -> *@ to datatypes of kind @(k -> *) -> (l -> *)@. This module
+-- @* -> Type@ to datatypes of kind @(k -> Type) -> (l -> Type)@. This module
 -- also derives a number of derived combinators.
 --
 -- The actual instances are defined in "Data.SOP.NP" and
@@ -81,6 +81,7 @@ module Data.SOP.Classes
   , htoI
   ) where
 
+import Data.Kind (Type)
 import Data.SOP.BasicFunctors
 import Data.SOP.Constraint
 
@@ -90,7 +91,7 @@ import Data.SOP.Constraint
 
 -- | A generalization of 'Control.Applicative.pure' or
 -- 'Control.Monad.return' to higher kinds.
-class HPure (h :: (k -> *) -> (l -> *)) where
+class HPure (h :: (k -> Type) -> (l -> Type)) where
   -- | Corresponds to 'Control.Applicative.pure' directly.
   --
   -- /Instances:/
@@ -154,14 +155,14 @@ fn_3 f = Fn $ \x -> Fn $ \x' -> Fn $ \x'' -> f x x' x''
 fn_4 f = Fn $ \x -> Fn $ \x' -> Fn $ \x'' -> Fn $ \x''' -> f x x' x'' x'''
 
 -- | Maps a structure to the same structure.
-type family Same (h :: (k1 -> *) -> (l1 -> *)) :: (k2 -> *) -> (l2 -> *)
+type family Same (h :: (k1 -> Type) -> (l1 -> Type)) :: (k2 -> Type) -> (l2 -> Type)
 
 -- | Maps a structure containing sums to the corresponding
 -- product structure.
-type family Prod (h :: (k -> *) -> (l -> *)) :: (k -> *) -> (l -> *)
+type family Prod (h :: (k -> Type) -> (l -> Type)) :: (k -> Type) -> (l -> Type)
 
 -- | A generalization of 'Control.Applicative.<*>'.
-class (Prod (Prod h) ~ Prod h, HPure (Prod h)) => HAp (h  :: (k -> *) -> (l -> *)) where
+class (Prod (Prod h) ~ Prod h, HPure (Prod h)) => HAp (h  :: (k -> Type) -> (l -> Type)) where
 
   -- | Corresponds to 'Control.Applicative.<*>'.
   --
@@ -349,11 +350,11 @@ hczipWith3 = hcliftA3
 -- * Collapsing homogeneous structures
 
 -- | Maps products to lists, and sums to identities.
-type family CollapseTo (h :: (k -> *) -> (l -> *)) (x :: *) :: *
+type family CollapseTo (h :: (k -> Type) -> (l -> Type)) (x :: Type) :: Type
 
 -- | A class for collapsing a heterogeneous structure into
 -- a homogeneous one.
-class HCollapse (h :: (k -> *) -> (l -> *)) where
+class HCollapse (h :: (k -> Type) -> (l -> Type)) where
 
   -- | Collapse a heterogeneous structure with homogeneous elements
   -- into a homogeneous structure.
@@ -379,7 +380,7 @@ class HCollapse (h :: (k -> *) -> (l -> *)) where
 --
 -- @since 0.3.2.0
 --
-class HTraverse_ (h :: (k -> *) -> (l -> *)) where
+class HTraverse_ (h :: (k -> Type) -> (l -> Type)) where
 
   -- | Corresponds to 'Data.Foldable.traverse_'.
   --
@@ -428,7 +429,7 @@ hcfoldMap p f = unK . hctraverse_ p (K . f)
 -- * Sequencing effects
 
 -- | A generalization of 'Data.Traversable.sequenceA'.
-class HAp h => HSequence (h :: (k -> *) -> (l -> *)) where
+class HAp h => HSequence (h :: (k -> Type) -> (l -> Type)) where
 
   -- | Corresponds to 'Data.Traversable.sequenceA'.
   --
@@ -505,7 +506,7 @@ hsequenceK = hsequence' . hliftA (Comp . fmap K . unK)
 -- | A class for determining which choice in a sum-like structure
 -- a value represents.
 --
-class HIndex (h :: (k -> *) -> (l -> *)) where
+class HIndex (h :: (k -> Type) -> (l -> Type)) where
 
   -- | If 'h' is a sum-like structure representing a choice
   -- between @n@ different options, and @x@ is a value of
@@ -540,12 +541,12 @@ class HIndex (h :: (k -> *) -> (l -> *)) where
 --
 -- @since 0.2.4.0
 --
-type family UnProd (h :: (k -> *) -> (l -> *)) :: (k -> *) -> (l -> *)
+type family UnProd (h :: (k -> Type) -> (l -> Type)) :: (k -> Type) -> (l -> Type)
 
 -- | A class for applying all injections corresponding to a sum-like
 -- structure to a table containing suitable arguments.
 --
-class (UnProd (Prod h) ~ h) => HApInjs (h :: (k -> *) -> (l -> *)) where
+class (UnProd (Prod h) ~ h) => HApInjs (h :: (k -> Type) -> (l -> Type)) where
 
   -- | For a given table (product-like structure), produce a list where
   -- each element corresponds to the application of an injection function
@@ -580,7 +581,7 @@ class (UnProd (Prod h) ~ h) => HApInjs (h :: (k -> *) -> (l -> *)) where
 --
 -- @since 0.2.5.0
 --
-class HExpand (h :: (k -> *) -> (l -> *)) where
+class HExpand (h :: (k -> Type) -> (l -> Type)) where
 
   -- | Expand a given sum structure into a corresponding product
   -- structure by placing the value contained in the sum into the
@@ -631,7 +632,7 @@ class HExpand (h :: (k -> *) -> (l -> *)) where
 --
 -- @since 0.3.1.0
 --
-class (Same h1 ~ h2, Same h2 ~ h1) => HTrans (h1 :: (k1 -> *) -> (l1 -> *)) (h2 :: (k2 -> *) -> (l2 -> *)) where
+class (Same h1 ~ h2, Same h2 ~ h1) => HTrans (h1 :: (k1 -> Type) -> (l1 -> Type)) (h2 :: (k2 -> Type) -> (l2 -> Type)) where
 
   -- | Transform a structure into a related structure given a conversion
   -- function for the elements.

--- a/sop-core/src/Data/SOP/Classes.hs
+++ b/sop-core/src/Data/SOP/Classes.hs
@@ -22,8 +22,8 @@
 -- various classes in this module that allow the necessary
 -- generalization.
 --
--- The classes typically lift concepts that exist for kinds @*@ or
--- @* -> Type@ to datatypes of kind @(k -> Type) -> (l -> Type)@. This module
+-- The classes typically lift concepts that exist for kinds @Type@ or
+-- @Type -> Type@ to datatypes of kind @(k -> Type) -> (l -> Type)@. This module
 -- also derives a number of derived combinators.
 --
 -- The actual instances are defined in "Data.SOP.NP" and

--- a/sop-core/src/Data/SOP/Constraint.hs
+++ b/sop-core/src/Data/SOP/Constraint.hs
@@ -13,8 +13,7 @@ module Data.SOP.Constraint
   ) where
 
 import Data.Coerce
-import Data.Kind (Type)
-import GHC.Exts (Constraint)
+import Data.Kind (Type, Constraint)
 
 import Data.SOP.Sing
 

--- a/sop-core/src/Data/SOP/Constraint.hs
+++ b/sop-core/src/Data/SOP/Constraint.hs
@@ -13,6 +13,7 @@ module Data.SOP.Constraint
   ) where
 
 import Data.Coerce
+import Data.Kind (Type)
 import GHC.Exts (Constraint)
 
 import Data.SOP.Sing
@@ -218,21 +219,21 @@ instance Top x
 -- The family 'AllN' expands to 'All' or 'All2' depending on whether
 -- the argument is indexed by a list or a list of lists.
 --
-type family AllN (h :: (k -> *) -> (l -> *)) (c :: k -> Constraint) :: l -> Constraint
+type family AllN (h :: (k -> Type) -> (l -> Type)) (c :: k -> Constraint) :: l -> Constraint
 
 -- | A generalization of 'AllZip' and 'AllZip2'.
 --
 -- The family 'AllZipN' expands to 'AllZip' or 'AllZip2' depending on
 -- whther the argument is indexed by a list or a list of lists.
 --
-type family AllZipN (h :: (k -> *) -> (l -> *)) (c :: k1 -> k2 -> Constraint) :: l1 -> l2 -> Constraint
+type family AllZipN (h :: (k -> Type) -> (l -> Type)) (c :: k1 -> k2 -> Constraint) :: l1 -> l2 -> Constraint
 
 -- | A generalization of 'SListI'.
 --
 -- The family 'SListIN' expands to 'SListI' or 'SListI2' depending
 -- on whether the argument is indexed by a list or a list of lists.
 --
-type family SListIN (h :: (k -> *) -> (l -> *)) :: l -> Constraint
+type family SListIN (h :: (k -> Type) -> (l -> Type)) :: l -> Constraint
 
 instance
   {-# OVERLAPPABLE #-}

--- a/sop-core/src/Data/SOP/NP.hs
+++ b/sop-core/src/Data/SOP/NP.hs
@@ -88,6 +88,7 @@ module Data.SOP.NP
   ) where
 
 import Data.Coerce
+import Data.Kind (Type)
 import Data.Proxy (Proxy(..))
 import Unsafe.Coerce
 import Data.Semigroup (Semigroup (..))
@@ -127,7 +128,7 @@ import Data.SOP.Sing
 -- > K 0      :* K 1     :* Nil  ::  NP (K Int) '[ Char, Bool ]
 -- > Just 'x' :* Nothing :* Nil  ::  NP Maybe   '[ Char, Bool ]
 --
-data NP :: (k -> *) -> [k] -> * where
+data NP :: (k -> Type) -> [k] -> Type where
   Nil  :: NP f '[]
   (:*) :: f x -> NP f xs -> NP f (x ': xs)
 
@@ -175,7 +176,7 @@ instance All (NFData `Compose` f) xs => NFData (NP f xs) where
 -- information that is available for all arguments of all constructors
 -- of a datatype.
 --
-newtype POP (f :: (k -> *)) (xss :: [[k]]) = POP (NP (NP f) xss)
+newtype POP (f :: (k -> Type)) (xss :: [[k]]) = POP (NP (NP f) xss)
 
 deriving instance (Show (NP (NP f) xss)) => Show (POP f xss)
 deriving instance (Eq   (NP (NP f) xss)) => Eq   (POP f xss)
@@ -339,7 +340,7 @@ tl (_x :* xs) = xs
 --
 -- A projection is a function from the n-ary product to a single element.
 --
-type Projection (f :: k -> *) (xs :: [k]) = K (NP f xs) -.-> f
+type Projection (f :: k -> Type) (xs :: [k]) = K (NP f xs) -.-> f
 
 -- | Compute all projections from an n-ary product.
 --
@@ -507,7 +508,7 @@ collapse_NP  ::              NP  (K a) xs  ->  [a]
 --
 -- /Example:/
 --
--- >>> collapse_POP (POP ((K 'a' :* Nil) :* (K 'b' :* K 'c' :* Nil) :* Nil) :: POP (K Char) '[ '[(a :: *)], '[b, c] ])
+-- >>> collapse_POP (POP ((K 'a' :* Nil) :* (K 'b' :* K 'c' :* Nil) :* Nil) :: POP (K Char) '[ '[(a :: Type)], '[b, c] ])
 -- ["a","bc"]
 --
 -- (The type signature is only necessary in this case to fix the kind of the type variables.)

--- a/sop-core/src/Data/SOP/NS.hs
+++ b/sop-core/src/Data/SOP/NS.hs
@@ -89,7 +89,8 @@ module Data.SOP.NS
   ) where
 
 import Data.Coerce
-import Data.Proxy
+import Data.Kind (Type)
+import Data.Proxy (Proxy (..))
 import Unsafe.Coerce
 
 import Control.DeepSeq (NFData(..))
@@ -142,7 +143,7 @@ import Data.SOP.Sing
 -- > S (Z (I True)) :: NS I       '[ Char, Bool ]
 -- > S (Z (K 1))    :: NS (K Int) '[ Char, Bool ]
 --
-data NS :: (k -> *) -> [k] -> * where
+data NS :: (k -> Type) -> [k] -> Type where
   Z :: f x -> NS f (x ': xs)
   S :: NS f xs -> NS f (x ': xs)
 
@@ -209,7 +210,7 @@ instance HIndex NS where
 -- constructors, the product structure represents the arguments of
 -- each constructor.
 --
-newtype SOP (f :: (k -> *)) (xss :: [[k]]) = SOP (NS (NP f) xss)
+newtype SOP (f :: (k -> Type)) (xss :: [[k]]) = SOP (NS (NP f) xss)
 
 deriving instance (Show (NS (NP f) xss)) => Show (SOP f xss)
 deriving instance (Eq   (NS (NP f) xss)) => Eq   (SOP f xss)
@@ -262,7 +263,7 @@ instance HIndex SOP where
 -- If we pick @a@ to be an element of @xs@, this indeed corresponds to an
 -- injection into the sum.
 --
-type Injection (f :: k -> *) (xs :: [k]) = f -.-> K (NS f xs)
+type Injection (f :: k -> Type) (xs :: [k]) = f -.-> K (NS f xs)
 
 -- | Compute all injections into an n-ary sum.
 --

--- a/sop-core/src/Data/SOP/Sing.hs
+++ b/sop-core/src/Data/SOP/Sing.hs
@@ -19,6 +19,8 @@ module Data.SOP.Sing
   , lengthSing
   ) where
 
+import Data.Kind (Type)
+
 -- * Singletons
 
 -- | Explicit singleton list.
@@ -34,7 +36,7 @@ module Data.SOP.Sing
 --
 -- @since 0.2
 --
-data SList :: [k] -> * where
+data SList :: [k] -> Type where
   SNil  :: SList '[]
   SCons :: SListI xs => SList (x ': xs)
 
@@ -83,7 +85,7 @@ type Sing = SList
 
 -- | Occassionally it is useful to have an explicit, term-level, representation
 -- of type-level lists (esp because of https://ghc.haskell.org/trac/ghc/ticket/9108)
-data Shape :: [k] -> * where
+data Shape :: [k] -> Type where
   ShapeNil  :: Shape '[]
   ShapeCons :: SListI xs => Shape xs -> Shape (x ': xs)
 


### PR DESCRIPTION
Supersedes #67.

Enabling `NoStarIsType` bans from accidental use of `*` as `Type`.