### PR TITLE
Refactor SListI to be a special case of All

### DIFF
--- a/generics-sop/src/Generics/SOP.hs
+++ b/generics-sop/src/Generics/SOP.hs
@@ -345,6 +345,8 @@ module Generics.SOP (
     -- ** Mapping constraints
   , All
   , All2
+  , cpara_SList
+  , ccase_SList
   , AllZip
   , AllZip2
   , AllN
@@ -357,15 +359,15 @@ module Generics.SOP (
   , SameShapeAs
     -- ** Singletons
   , SList(..)
-  , SListI(..)
+  , SListI
   , SListI2
-  , Sing
-  , SingI(..)
+  , sList
+  , para_SList
+  , case_SList
     -- *** Shape of type-level lists
   , Shape(..)
   , shape
   , lengthSList
-  , lengthSing
     -- ** Re-exports
 
 -- Workaround for lack of MIN_TOOL_VERSION macro in Cabal 1.18, see:

--- a/generics-sop/src/Generics/SOP/Metadata.hs
+++ b/generics-sop/src/Generics/SOP/Metadata.hs
@@ -22,7 +22,6 @@ import GHC.Generics (Associativity(..))
 
 import Generics.SOP.Constraint
 import Generics.SOP.NP
-import Generics.SOP.Sing
 
 -- | Metadata for a datatype.
 --

--- a/generics-sop/src/Generics/SOP/Type/Metadata.hs
+++ b/generics-sop/src/Generics/SOP/Type/Metadata.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE PolyKinds, UndecidableInstances #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 -- | Type-level metadata
 --
 -- This module provides datatypes (to be used promoted) that can represent the

--- a/generics-sop/src/Generics/SOP/Universe.hs
+++ b/generics-sop/src/Generics/SOP/Universe.hs
@@ -10,7 +10,6 @@ import qualified GHC.Generics as GHC
 import Generics.SOP.BasicFunctors
 import Generics.SOP.Constraint
 import Generics.SOP.NS
-import Generics.SOP.Sing
 import Generics.SOP.GGP
 import Generics.SOP.Metadata
 import qualified Generics.SOP.Type.Metadata as T

--- a/sop-core/src/Data/SOP.hs
+++ b/sop-core/src/Data/SOP.hs
@@ -104,6 +104,8 @@ module Data.SOP (
     -- ** Mapping constraints
   , All
   , All2
+  , cpara_SList
+  , ccase_SList
   , AllZip
   , AllZip2
   , AllN
@@ -116,15 +118,15 @@ module Data.SOP (
   , SameShapeAs
     -- ** Singletons
   , SList(..)
-  , SListI(..)
+  , SListI
   , SListI2
-  , Sing
-  , SingI(..)
+  , sList
+  , para_SList
+  , case_SList
     -- *** Shape of type-level lists
   , Shape(..)
   , shape
   , lengthSList
-  , lengthSing
     -- ** Re-exports
 
 -- Workaround for lack of MIN_TOOL_VERSION macro in Cabal 1.18, see:

--- a/sop-core/src/Data/SOP/Dict.hs
+++ b/sop-core/src/Data/SOP/Dict.hs
@@ -22,7 +22,6 @@ import Data.Proxy
 import Data.SOP.Classes
 import Data.SOP.Constraint
 import Data.SOP.NP
-import Data.SOP.Sing
 
 -- | An explicit dictionary carrying evidence of a
 -- class constraint.


### PR DESCRIPTION
This fixes #32.

It remains to be decided whether this should go into 0.4 or a later release, because it is a rather invasive change. I believe the external interface will behave mostly the same though.