### PR TITLE
Explicitly quantify the kind variable in `shape` and `lengthSList`

### DIFF
--- a/sop-core/src/Data/SOP/Sing.hs
+++ b/sop-core/src/Data/SOP/Sing.hs
@@ -1,4 +1,9 @@
 {-# LANGUAGE PolyKinds, StandaloneDeriving #-}
+#if __GLASGOW_HASKELL__ < 806
+-- Before GHC 8.6, TypeInType was required to explicitly quantify kind variables.
+-- After GHC 8.6, this feature was incorporated into PolyKinds.
+{-# LANGUAGE TypeInType #-}
+#endif
 -- | Singleton types corresponding to type-level data structures.
 --
 -- The implementation is similar, but subtly different to that of the
@@ -93,7 +98,7 @@ deriving instance Eq   (Shape xs)
 deriving instance Ord  (Shape xs)
 
 -- | The shape of a type-level list.
-shape :: forall (xs :: [k]). SListI xs => Shape xs
+shape :: forall k (xs :: [k]). SListI xs => Shape xs
 shape = case sList :: SList xs of
           SNil  -> ShapeNil
           SCons -> ShapeCons shape
@@ -102,7 +107,7 @@ shape = case sList :: SList xs of
 --
 -- @since 0.2
 --
-lengthSList :: forall (xs :: [k]) proxy. SListI xs => proxy xs -> Int
+lengthSList :: forall k (xs :: [k]) proxy. SListI xs => proxy xs -> Int
 lengthSList _ = lengthShape (shape :: Shape xs)
   where
     lengthShape :: forall xs'. Shape xs' -> Int


### PR DESCRIPTION
GHC 8.10 (HEAD) implements GHC [proposal 24](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0024-no-kind-vars.rst), which requires kind variables to be quantified alongside type variables in a top-level `forall`. Currently, the kind variables in the top-level `forall`s of the `shape` and `lengthSList` functions are not explicitly quantified, which means that `sop-core` fails to build on GHC HEAD.

Luckily, the fix is backwards compatible, since the earliest version of GHC that `sop-core` supports now is GHC 8.0, which includes the ability to explicitly quantify kind variables. Note that this ability required the use of the `TypeInType` extension prior to GHC 8.6, which is why I selectively enable it on old GHCs, but after 8.6 it only requires `PolyKinds`.

Patch adapted from https://gitlab.haskell.org/ghc/head.hackage/commit/127a34f5be8c0075768b932d3609020db7f06b36.