### PR TITLE
RFC: TH support for data families

### DIFF
--- a/generics-sop/generics-sop.cabal
+++ b/generics-sop/generics-sop.cabal
@@ -68,6 +68,7 @@ library
   build-depends:       base                 >= 4.9  && < 5,
                        sop-core             == 0.5.0.*,
                        template-haskell     >= 2.8  && < 2.16,
+                       th-abstraction       >= 0.3  && < 0.4,
                        ghc-prim             >= 0.3  && < 0.6
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
This leverages the `th-abstraction` library to grant `Generics.SOP.TH` the ability to generate code for vanilla data types and data families alike. This patch looks large, but most of it is internal refactoring to use `th-abstraction`'s intermediate data types where necessary (e.g., `DatatypeInfo` instead of `Dec`, `ConstructorInfo` instead of `Con`, etc.).

This does incur an extra library dependency in `th-abstraction`, but it's a very small one, as it does not depend on any non-GHC-boot libraries itself. It's also used by other libraries to enable data family support, such as `aeson` and `th-lift`.

Fixes #111 along the way.