### PR TITLE
Make sop-core forward-compatible with GHC proposal 229

### DIFF
--- a/sop-core/src/Data/SOP/Dict.hs
+++ b/sop-core/src/Data/SOP/Dict.hs
@@ -68,7 +68,7 @@ mapAll f Dict = (all_NP . hmap f . unAll_NP) Dict
 mapAll2 :: forall c d xss .
            (forall a . Dict c a -> Dict d a)
         -> Dict (All2 c) xss -> Dict (All2 d) xss
-mapAll2 f d @ Dict = (all2 . mapAll (mapAll f) . unAll2) d
+mapAll2 f d@Dict = (all2 . mapAll (mapAll f) . unAll2) d
 
 -- | If two constraints 'c' and 'd' hold over a type-level
 -- list 'xs', then the combination of both constraints holds
@@ -77,7 +77,7 @@ mapAll2 f d @ Dict = (all2 . mapAll (mapAll f) . unAll2) d
 -- @since 0.2
 --
 zipAll :: Dict (All c) xs -> Dict (All d) xs -> Dict (All (c `And` d)) xs
-zipAll dc @ Dict dd = all_NP (hzipWith (\ Dict Dict -> Dict) (unAll_NP dc) (unAll_NP dd))
+zipAll dc@Dict dd = all_NP (hzipWith (\ Dict Dict -> Dict) (unAll_NP dc) (unAll_NP dd))
 
 -- | If two constraints 'c' and 'd' hold over a type-level
 -- list of lists 'xss', then the combination of both constraints


### PR DESCRIPTION
GHC HEAD now implements [proposal 229](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0229-whitespace-bang-patterns.rst), which makes the parser more sensitive to whitespace around `@` characters in as-patterns. In particular, `@`s in as-patterns are no longer permitted to have preceding or trailing whitespace, which causes `sop-core` to fail to compile on HEAD:

```
[7 of 8] Compiling Data.SOP.Dict    ( src/Data/SOP/Dict.hs, interpreted )

src/Data/SOP/Dict.hs:71:1: error: Parse error in pattern: mapAll2
   |
71 | mapAll2 f d @ Dict = (all2 . mapAll (mapAll f) . unAll2) d
   | ^^^^^^^^^^^
```

The fix is simple: remove the extra whitespace, which this patch accomplishes.