### PR TITLE
Fancier Shape

### DIFF
--- a/sop-core/src/Data/SOP.hs
+++ b/sop-core/src/Data/SOP.hs
@@ -126,6 +126,7 @@ module Data.SOP (
     -- *** Shape of type-level lists
   , Shape(..)
   , shape
+  , shapeP
   , lengthSList
     -- ** Re-exports
 


### PR DESCRIPTION
By changing recursive Shape xs into Proxy xs we don't
lose expressivity, but get a better (non quadratic) representation.

As an addition, we parametrise Shape by `c :: k -> Constraint`,
making it able to represent nested singletons,
e.g. `Shape SListI xss` for list-of-lists.
Partly for that reason, there's now a proxy for a head too.

These are motivated by my experience with writing stuff
for type-families, e.g. Append. Sooner or later, we'd want to have
function:

    allAppend :: (All c xs, All c ys)
              => ... proxies ...
              -> (All c (Append xs ys) => r) -> r

which can be implemented as

    allAppend
      :: forall c xs ys r proxyC proxy proxy'. (All c xs, All c ys)
      => proxyC c -> proxy xs -> proxy' ys
      -> (All c (Append xs ys) => r) -> r
    allAppend _ xs _ = go (shapeP xs) where
      go :: Shape c xs' -> (All c (Append xs' ys) => r) -> r
      go ShapeNil          k = k
      go (ShapeCons _ xs') k = go (shapeP xs') k

This doesn't yet demonstrate the need for the head proxy,
but it's needed in similar `allConcat` function for the `Concat`
type-family.

