### PR TITLE
Use th-abstraction-0.4, support GHC-9.0

### DIFF
--- a/generics-sop/CHANGELOG.md
+++ b/generics-sop/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.1.1 (2020-xx-yy)
+
+* Compatibility with GHC-9.0
+
 # 0.5.1.0 (2020-03-29)
 
 * Compatibility with GHC-8.10 (thanks to Ryan Scott).

--- a/generics-sop/generics-sop.cabal
+++ b/generics-sop/generics-sop.cabal
@@ -1,5 +1,5 @@
 name:                generics-sop
-version:             0.5.1.0
+version:             0.5.1.1
 synopsis:            Generic Programming using True Sums of Products
 description:
   A library to support the definition of generic functions.
@@ -65,11 +65,11 @@ library
                        Generics.SOP.NP
                        Generics.SOP.NS
                        Generics.SOP.Sing
-  build-depends:       base                 >= 4.9  && < 4.15,
+  build-depends:       base                 >= 4.9  && < 4.16,
                        sop-core             == 0.5.0.*,
-                       template-haskell     >= 2.8  && < 2.17,
-                       th-abstraction       >= 0.3  && < 0.5,
-                       ghc-prim             >= 0.3  && < 0.7
+                       template-haskell     >= 2.8  && < 2.18,
+                       th-abstraction       >= 0.4  && < 0.5,
+                       ghc-prim             >= 0.3  && < 0.8
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/generics-sop/src/Generics/SOP/Instances.hs
+++ b/generics-sop/src/Generics/SOP/Instances.hs
@@ -262,7 +262,9 @@ deriveGeneric ''SrcLoc -- new
 deriveGeneric ''RuntimeRep -- new
 deriveGeneric ''VecCount -- new
 deriveGeneric ''VecElem -- new
+#if !MIN_VERSION_base(4,15,0)
 deriveGeneric ''SpecConstrAnnotation -- new
+#endif
 
 -- From GHC.Generics:
 deriveGeneric ''GHC.Generics.K1 -- new

--- a/sop-core/sop-core.cabal
+++ b/sop-core/sop-core.cabal
@@ -41,7 +41,7 @@ library
                        Data.SOP.NP
                        Data.SOP.NS
                        Data.SOP.Sing
-  build-depends:       base                 >= 4.9  && < 4.15,
+  build-depends:       base                 >= 4.9  && < 4.16,
                        deepseq              >= 1.3  && < 1.5
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
benchmarks fail on CI, but this should soon be resolved when `aeson` supports `th-abstraction-0.4`