### PR TITLE
Expose SListI in coalgebras

### DIFF
--- a/sop-core/src/Data/SOP/NP.hs
+++ b/sop-core/src/Data/SOP/NP.hs
@@ -755,7 +755,7 @@ ccata_NP _ nil cons = go
 ana_NP ::
      forall s f xs .
      SListI xs
-  => (forall y ys . s (y ': ys) -> (f y, s ys))
+  => (forall y ys . SListI ys => s (y ': ys) -> (f y, s ys))
   -> s xs
   -> NP f xs
 ana_NP uncons =
@@ -773,7 +773,7 @@ ana_NP uncons =
 cana_NP ::
      forall c proxy s f xs . (All c xs)
   => proxy c
-  -> (forall y ys . c y => s (y ': ys) -> (f y, s ys))
+  -> (forall y ys . (c y, SListI ys) => s (y ': ys) -> (f y, s ys))
   -> s xs
   -> NP f xs
 cana_NP _ uncons = go sList

--- a/sop-core/src/Data/SOP/NS.hs
+++ b/sop-core/src/Data/SOP/NS.hs
@@ -804,7 +804,7 @@ ccata_NS _ z s = go
 ana_NS ::
      forall s f xs . (SListI xs)
   => (forall r . s '[] -> r)
-  -> (forall y ys . s (y ': ys) -> Either (f y) (s ys))
+  -> (forall y ys . SListI ys => s (y ': ys) -> Either (f y) (s ys))
   -> s xs
   -> NS f xs
 ana_NS refute decide =
@@ -819,7 +819,7 @@ cana_NS :: forall c proxy s f xs .
      (All c xs)
   => proxy c
   -> (forall r . s '[] -> r)
-  -> (forall y ys . c y => s (y ': ys) -> Either (f y) (s ys))
+  -> (forall y ys . (c y, SListI ys) => s (y ': ys) -> Either (f y) (s ys))
   -> s xs
   -> NS f xs
 cana_NS _ refute decide = go sList


### PR DESCRIPTION
Hello there. I've been making good use of the handy `[c]ana_N{S,P}` functions for constructing things coinductively.

Unfortunately I've run into a bit of a hiccup: the continuations expected by these functions are not granted `SListI` constraints on their list-kinded type variables. Since it's not possible to case analyze naked type variables in Haskell (even when their kind is a promoted inductive type), this restricts you from doing much of use, unless you explicitly pass dictionaries into your `s`.

I believe the correct thing to do here is to pass down the sub-constraint-dictionary revealed by pattern matching into the continuation.