### PR TITLE
Support ghc 9.2

### DIFF
--- a/generics-sop/generics-sop.cabal
+++ b/generics-sop/generics-sop.cabal
@@ -42,7 +42,7 @@ category:            Generics
 build-type:          Simple
 cabal-version:       >=1.10
 extra-source-files:  CHANGELOG.md doctest.sh
-tested-with:         GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.2, GHC == 8.10.4, GHC == 9.0.1
+tested-with:         GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.2, GHC == 8.10.4, GHC == 9.0.1, GHC == 9.2.1
 
 source-repository head
   type:                git
@@ -65,11 +65,11 @@ library
                        Generics.SOP.NP
                        Generics.SOP.NS
                        Generics.SOP.Sing
-  build-depends:       base                 >= 4.9  && < 4.16,
+  build-depends:       base                 >= 4.9  && < 4.17,
                        sop-core             == 0.5.0.*,
-                       template-haskell     >= 2.8  && < 2.18,
+                       template-haskell     >= 2.8  && < 2.19,
                        th-abstraction       >= 0.4  && < 0.5,
-                       ghc-prim             >= 0.3  && < 0.8
+                       ghc-prim             >= 0.3  && < 0.9
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/generics-sop/src/Generics/SOP/Instances.hs
+++ b/generics-sop/src/Generics/SOP/Instances.hs
@@ -206,7 +206,7 @@ deriveGeneric ''Data.Semigroup.Max -- new
 deriveGeneric ''Data.Semigroup.First -- new
 deriveGeneric ''Data.Semigroup.Last -- new
 deriveGeneric ''Data.Semigroup.WrappedMonoid -- new
-#if __GLASGOW_HASKELL__ <= 901
+#if !MIN_VERSION_base(4,16,0)
 deriveGeneric ''Data.Semigroup.Option -- new
 #endif
 deriveGeneric ''Data.Semigroup.Arg -- new

--- a/generics-sop/src/Generics/SOP/Instances.hs
+++ b/generics-sop/src/Generics/SOP/Instances.hs
@@ -206,7 +206,9 @@ deriveGeneric ''Data.Semigroup.Max -- new
 deriveGeneric ''Data.Semigroup.First -- new
 deriveGeneric ''Data.Semigroup.Last -- new
 deriveGeneric ''Data.Semigroup.WrappedMonoid -- new
+#if __GLASGOW_HASKELL__ <= 901
 deriveGeneric ''Data.Semigroup.Option -- new
+#endif
 deriveGeneric ''Data.Semigroup.Arg -- new
 
 -- From Data.Version:

--- a/sop-core/sop-core.cabal
+++ b/sop-core/sop-core.cabal
@@ -25,7 +25,7 @@ category:            Data
 build-type:          Simple
 cabal-version:       >=1.10
 extra-source-files:  CHANGELOG.md doctest.sh
-tested-with:         GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.2, GHC == 8.10.4, GHC == 9.0.1
+tested-with:         GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.2, GHC == 8.10.4, GHC == 9.0.1, GHC == 9.2.1
 
 source-repository head
   type:                git
@@ -41,7 +41,7 @@ library
                        Data.SOP.NP
                        Data.SOP.NS
                        Data.SOP.Sing
-  build-depends:       base                 >= 4.9  && < 4.16,
+  build-depends:       base                 >= 4.9  && < 4.17,
                        deepseq              >= 1.3  && < 1.5
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
Fixes #145

﻿Using `__GLASGOW_HASKELL__` because there doesn't seem to be any sort of MAX_VERSION_base
