### PR TITLE
Move ccase_SList into All class

### DIFF
--- a/sop-core/src/Data/SOP/Constraint.hs
+++ b/sop-core/src/Data/SOP/Constraint.hs
@@ -73,28 +73,33 @@ class (AllF c xs, SListI xs) => All (c :: k -> Constraint) (xs :: [k]) where
     -> (forall y ys . (c y, All c ys) => r ys -> r (y ': ys))
     -> r xs
 
+  -- | Constrained case distinction on a type-level list.
+  --
+  -- @since 0.4.0.0
+  --
+  ccase_SList ::
+       All c xs
+    => proxy c
+    -> ((xs ~ '[]) => r '[])
+    -> (forall y ys . (c y, All c ys, (y ': ys) ~ xs) => r (y ': ys))
+    -> r xs
+
 instance All c '[] where
   cpara_SList _p nil _cons = nil
   {-# INLINE cpara_SList #-}
+
+  ccase_SList _p nil _cons =
+    nil
+  {-# INLINE ccase_SList #-}
 
 instance (c x, All c xs) => All c (x ': xs) where
   cpara_SList p nil cons =
     cons (cpara_SList p nil cons)
   {-# INLINE cpara_SList #-}
 
--- | Constrained case distinction on a type-level list.
---
--- @since 0.4.0.0
---
-ccase_SList ::
-     All c xs
-  => proxy c
-  -> r '[]
-  -> (forall y ys . (c y, All c ys) => r (y ': ys))
-  -> r xs
-ccase_SList p nil cons =
-  cpara_SList p nil (const cons)
-{-# INLINE ccase_SList #-}
+  ccase_SList _p _nil cons =
+    cons
+  {-# INLINE ccase_SList #-}
 
 -- | Type family used to implement 'All'.
 --


### PR DESCRIPTION
This allows us to provide more type information to the continuations.

Specifically: cpara_SList doesn't allow the `cons` continuation to know that there's a connection between `(y ': ys)` and `xs`.  With this change, `ccase_SList` *does* provide that connection, i.e. that `(y ': ys) ~ xs`.

I'm not sure whether this is a breaking change or not: it should provide strictly more info to the continuations, and I don't think it's sensible for anyone to be defining their own instances of `All`.