### PR TITLE
Support building with `th-abstraction-0.5.*`

### DIFF
--- a/generics-sop/generics-sop.cabal
+++ b/generics-sop/generics-sop.cabal
@@ -68,7 +68,7 @@ library
   build-depends:       base                 >= 4.9  && < 4.18,
                        sop-core             == 0.5.0.*,
                        template-haskell     >= 2.8  && < 2.20,
-                       th-abstraction       >= 0.4  && < 0.5,
+                       th-abstraction       >= 0.4  && < 0.6,
                        ghc-prim             >= 0.3  && < 0.10
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
`th-abstraction-0.5.0.0` introduces a `TypeData` constructor for `DatatypeVariant` that characterizes `type data` declarations (introduced in GHC 9.6). Because `type data` data constructors only exist at the type level, not the value level, it doesn't make sense to define `Generic` instances for a `type data` declaration. As a result, this patch makes it an error to use `generics-sop`'s TH machinery in conjunction with a `type data` declaration.