### PR TITLE
[feat] add initial support for unlifted types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,10 @@
 dist/
 dist-newstyle/
 .ghc.environment.*
+
+# direnv
+.envrc
+.direnv
+
+# nix 
+result*

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,7 @@
 packages: sop-core/ generics-sop/
+
+repository hackage.haskell.org
+  url: http://hackage.haskell.org/packages/archive
+
+index-state:
+  , hackage.haskell.org 2023-03-21T09:55:23Z

--- a/generics-sop/src/Generics/SOP.hs
+++ b/generics-sop/src/Generics/SOP.hs
@@ -242,6 +242,7 @@ module Generics.SOP (
   , NS(..)
   , SOP(..)
   , unSOP
+  , unUSOP
   , POP(..)
   , unPOP
     -- * Metadata

--- a/generics-sop/src/Generics/SOP/Instances.hs
+++ b/generics-sop/src/Generics/SOP/Instances.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE EmptyCase, UnliftedDatatypes #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS_GHC -freduction-depth=100 #-}
@@ -73,9 +73,9 @@ import Generics.SOP.TH
 
 -- Types from Generics.SOP:
 
-deriveGeneric ''I
-deriveGeneric ''K
-deriveGeneric ''(:.:)
+deriveGeneric 'I
+deriveGeneric 'K
+deriveGeneric 'Comp
 deriveGeneric ''(-.->) -- new
 
 -- Cannot derive instances for Sing

--- a/generics-sop/test/Example.hs
+++ b/generics-sop/test/Example.hs
@@ -13,9 +13,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# OPTIONS_GHC -Wno-unused-matches #-}
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
-{-# OPTIONS_GHC -fprint-explicit-kinds #-}
 module Main (main, toTreeC, toDataFamC) where
 
 import qualified GHC.Generics as GHC
@@ -25,7 +23,7 @@ import qualified Generics.SOP.Type.Metadata as T
 
 import HTransExample
 import GHC.Exts (UnliftedType, Levity (Unlifted))
-import Data.Kind (Constraint, Type)
+import Data.Kind (Constraint)
 
 -- Generic show, kind of
 gshow :: (Generic a, All2 Show (Code a)) => a -> String
@@ -245,12 +243,6 @@ gueq x y =
     fieldsSame UNil UNil = True
 
 instance UEq UT 
-
-type Wrap :: UnliftedType -> Type 
-data Wrap a = MkWrap a
-
-instance UEq a => Eq (Wrap a) where
-  MkWrap a == MkWrap b = a `ueq` b
 
 -- Tests
 main :: IO ()

--- a/sop-core/src/Data/SOP.hs
+++ b/sop-core/src/Data/SOP.hs
@@ -7,6 +7,7 @@ module Data.SOP (
   , NS(..)
   , SOP(..)
   , unSOP
+  , unUSOP
   , POP(..)
   , unPOP
     -- * Combinators

--- a/sop-core/src/Data/SOP/BasicFunctors.hs
+++ b/sop-core/src/Data/SOP/BasicFunctors.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE PolyKinds, DeriveGeneric, UnliftedNewtypes, StandaloneKindSignatures #-}
+{-# LANGUAGE TypeApplications #-}
 -- | Basic functors.
 --
 -- Definitions of the type-level equivalents of
@@ -76,9 +77,11 @@ data family K :: forall levin levout k. BoxedType levin -> k -> BoxedType levout
 newtype instance K @'Lifted @'Lifted a b = K a
   deriving (Functor, Foldable, Traversable, GHC.Generic)
 
-newtype instance K @'Unlifted @'Unlifted a b = UK a
+-- | @since 0.6.0.0
+newtype instance K @'Unlifted @'Unlifted a b = UK {unUK :: a}
 
-data instance K @'Unlifted @'Lifted a b = ULK a
+-- | @since 0.6.0.0
+data instance K @'Unlifted @'Lifted a b = ULK {unULK :: a}
 
 -- | @since 0.2.4.0
 instance Eq2 K where
@@ -132,7 +135,7 @@ instance Monoid a => Applicative (K a) where
   pure _      = K mempty
   K x <*> K y = K (mappend x y)
 
--- | Extract the contents of a 'K' value.
+-- | @since 0.6.0.0
 unK :: K a b -> a
 unK (K x) = x
 
@@ -144,9 +147,11 @@ data family I :: forall levin levout. BoxedType levin -> BoxedType levout
 newtype instance I @'Lifted @'Lifted a = I a
   deriving (Functor, Foldable, Traversable, GHC.Generic)
 
-newtype instance I @'Unlifted @'Unlifted a = UI a
+-- | @since 0.6.0.0
+newtype instance I @'Unlifted @'Unlifted a = UI {unUI :: a}
 
-data instance I @'Unlifted @'Lifted a = ULI a
+-- | @since 0.6.0.0
+data instance I @'Unlifted @'Lifted a = ULI {unULI :: a}
 
 -- | @since 0.4.0.0
 instance Semigroup a => Semigroup (I a) where
@@ -200,9 +205,11 @@ data family (:.:) :: forall levin levout k l.
 newtype instance (:.:) @'Lifted @'Lifted f g p = Comp (f (g p))
   deriving (GHC.Generic)
 
-newtype instance (:.:) @'Unlifted @'Unlifted f g p = UComp (f (g p))
+-- | @since 0.6.0.0
+newtype instance (:.:) @'Unlifted @'Unlifted f g p = UComp {unUComp :: f (g p)}
 
-data instance (:.:) @'Unlifted @'Lifted f g p = ULComp (f (g p))
+-- | @since 0.6.0.0
+data instance (:.:) @'Unlifted @'Lifted f g p = ULComp {unULComp :: f (g p)}
 
 infixr 7 :.:
 

--- a/sop-core/src/Data/SOP/NP.hs
+++ b/sop-core/src/Data/SOP/NP.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE UnliftedDatatypes #-}
+{-# LANGUAGE UnliftedNewtypes #-}
 {-# LANGUAGE TypeApplications #-}
 -- | n-ary products (and products of products)
 module Data.SOP.NP
@@ -105,7 +106,7 @@ import Data.SOP.BasicFunctors
 import Data.SOP.Classes
 import Data.SOP.Constraint
 import Data.SOP.Sing
-import GHC.Exts (Levity (Lifted, Unlifted))
+import GHC.Exts (Levity (Lifted, Unlifted), UnliftedType)
 
 -- | An n-ary product.
 --
@@ -194,7 +195,14 @@ instance All (NFData `Compose` f) xs => NFData (NP f xs) where
 -- information that is available for all arguments of all constructors
 -- of a datatype.
 --
-newtype POP (f :: (k -> Type)) (xss :: [[k]]) = POP (NP (NP f) xss)
+data family POP :: forall levin levout k. (k -> BoxedType levin) -> [[k]] -> BoxedType levout
+newtype instance POP @'Lifted @'Lifted f xss  = POP (NP (NP f) xss)
+
+-- | @since 0.6.0.0
+newtype instance POP @'Unlifted @'Unlifted f xss = UPOP {unUPOP :: NP (NP f) xss}
+
+-- | @since 0.6.0.0
+data instance POP @'Unlifted @'Lifted f xss = ULPOP {unULPOP :: NP (NP f) xss}
 
 deriving instance (Show (NP (NP f) xss)) => Show (POP f xss)
 deriving instance (Eq   (NP (NP f) xss)) => Eq   (POP f xss)

--- a/sop-core/src/Data/SOP/NP.hs
+++ b/sop-core/src/Data/SOP/NP.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UnliftedDatatypes #-}
+{-# LANGUAGE TypeApplications #-}
 -- | n-ary products (and products of products)
 module Data.SOP.NP
   ( -- * Datatypes
@@ -103,6 +105,7 @@ import Data.SOP.BasicFunctors
 import Data.SOP.Classes
 import Data.SOP.Constraint
 import Data.SOP.Sing
+import GHC.Exts (Levity (Lifted, Unlifted))
 
 -- | An n-ary product.
 --
@@ -132,11 +135,18 @@ import Data.SOP.Sing
 -- > K 0      :* K 1     :* Nil  ::  NP (K Int) '[ Char, Bool ]
 -- > Just 'x' :* Nothing :* Nil  ::  NP Maybe   '[ Char, Bool ]
 --
-data NP :: (k -> Type) -> [k] -> Type where
+data family NP :: forall levity k. (k -> BoxedType levity) -> [k] -> BoxedType levity
+data instance NP @'Lifted f xs where
   Nil  :: NP f '[]
-  (:*) :: f x -> NP f xs -> NP f (x ': xs)
+  (:*) :: f x -> NP  f xs -> NP f (x ': xs)
+
+data instance NP @'Unlifted f xs where
+  UNil :: NP f '[]
+  (::*) :: f x -> NP f xs -> NP f (x ': xs)
 
 infixr 5 :*
+infixr 5 ::*
+
 
 -- This is written manually,
 -- because built-in deriving doesn't use associativity information!

--- a/sop-core/src/Data/SOP/NS.hs
+++ b/sop-core/src/Data/SOP/NS.hs
@@ -14,7 +14,7 @@ module Data.SOP.NS
     NS(..)
   , SOP(..)
   , unSOP
-  , unUSOP
+
     -- * Constructing sums
   , Injection
   , injections
@@ -252,10 +252,14 @@ instance HIndex NS where
 -- constructors, the product structure represents the arguments of
 -- each constructor.
 --
-data family SOP :: forall levin levout k . (k -> BoxedType levin) -> [[k]] -> BoxedType levout
+data family SOP :: forall levin levout k. (k -> BoxedType levin) -> [[k]] -> BoxedType levout
 newtype instance SOP @'Lifted @'Lifted f xss = SOP (NS (NP f) xss)
-newtype instance SOP @'Unlifted @'Unlifted f xss = USOP (NS (NP f) xss)
-data instance SOP @'Unlifted @'Lifted f xss = ULSOP (NS (NP f) xss)
+
+-- | @since 0.6.0.0
+newtype instance SOP @'Unlifted @'Unlifted f xss = USOP {unUSOP :: NS (NP f) xss}
+
+-- | @since 0.6.0.0
+data instance SOP @'Unlifted @'Lifted f xss = ULSOP {unULSOP :: NS (NP f) xss}
 
 deriving instance (Show (NS (NP f) xss)) => Show (SOP f xss)
 deriving instance (Eq   (NS (NP f) xss)) => Eq   (SOP f xss)
@@ -268,9 +272,6 @@ instance (NFData (NS (NP f) xss)) => NFData (SOP f xss) where
 -- | Unwrap a sum of products.
 unSOP :: SOP f xss -> NS (NP f) xss
 unSOP (SOP xss) = xss
-
-unUSOP :: forall k (xss :: [[k]]) (f :: k -> UnliftedType). SOP @'Unlifted @'Unlifted f xss -> NS (NP f) xss
-unUSOP (USOP xss) = xss
 
 type instance AllN NS  c = All  c
 type instance AllN SOP c = All2 c


### PR DESCRIPTION
---

> **Note**
> This is a draft for adding support for `unlifted` types for `generics-sop`, according to #155 

---

### Status 

- [x] unlifted representations 
- [x] th generation for unlifted `Generic` 
- [x] levity polymorphic `Generic` 
- [x] example 
- [x] compiles on `ghc927`, `ghc944`, `ghc961`
- [x] more polymorphic `BasicFunctor`s (something like
  ```haskell
  data family I :: forall levin levout. TYPE ('BoxedRep levin) -> TYPE ('BoxedRep levout)
  data instance I @'Unlifted @'Lifted a = ULI a
  ... 
  ```
- [ ] make both the unlifted and the lifted repr derivable for an unlifted type (in the moment, only the unlifted is derivable by the TH code.)
- [ ] a whole lot of CPP to exclude these changes on ghc <92

---

> **Warning**
> Due to a bug in GHC, this only works on GHC 9.4 >= 9.4.6
> it hasn't been backported to GHC 9.6 but should exist in GHC 9.8
> I would also expect that it will get soon backported to GHC 9.6

