### PR TITLE
Add UnboxedTuples to Generics/SOP/Instances.hs

### DIFF
--- a/generics-sop/src/Generics/SOP/Instances.hs
+++ b/generics-sop/src/Generics/SOP/Instances.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE UnboxedTuples #-} -- needed on 9.8 for CodeBuffers instance
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS_GHC -freduction-depth=100 #-}
 {-# OPTIONS_GHC -fno-warn-deprecations #-}


### PR DESCRIPTION
GHC commit https://github.com/ghc/ghc/commit/fbe3fe003ac8d4a06 changed the type `CodeBuffers` to an unboxed tuple. As a result, `generics-sop` needs an extension to compile on head:

```
src/Generics/SOP/Instances.hs:298:1: error: [GHC-19590]
    • Illegal unboxed tuple type as function argument:
      (# State# RealWorld, CodingProgress, Buffer from, Buffer to #)
    • In the expansion of type synonym ‘GHC.IO.Encoding.Types.CodeBuffer#’
      In the type instance declaration for ‘Generics.SOP.Universe.Code’
      In the instance declaration for
        ‘Generics.SOP.Universe.Generic (BufferCodec from_ap4y to_ap4z state_ap4A)’
    Suggested fix: Perhaps you intended to use UnboxedTuples
    |
298 | deriveGeneric ''BufferCodec -- new
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
```