### PR TITLE
[feat] allow deriving via Generically

### DIFF
--- a/generics-sop/generics-sop.cabal
+++ b/generics-sop/generics-sop.cabal
@@ -70,6 +70,9 @@ library
                        template-haskell     >= 2.8  && < 2.21,
                        th-abstraction       >= 0.4  && < 0.6,
                        ghc-prim             >= 0.3  && < 0.11
+  if impl(ghc < 9.4.1)
+    build-depends:     generically
+
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/generics-sop/src/Generics/SOP.hs
+++ b/generics-sop/src/Generics/SOP.hs
@@ -195,6 +195,39 @@
 -- > instance NFData A where rnf = grnf
 -- > instance NFData a => NFData (B a) where rnf = grnf
 --
+-- == Deriving Generic
+--
+-- The 'Generic' class can also be derived in two ways
+-- (this uses @-XDerivingStrategies@ for more clarity)
+--
+-- === Using @-XDeriveAnyClass@
+--
+-- > {-# LANGUAGE DeriveGeneric, DerivingStrategies, DeriveAnyClass #-}
+-- >
+-- > import qualified GHC.Generics as GHC
+-- > import Generics.SOP
+-- > data A = B Bool | C Int
+-- >   deriving stock GHC.Generic
+-- >   deriving anyclass Generic
+--
+-- === Using @-XDerivingVia@ (GHC versions greater or equal 8.6.1)
+--
+-- > {-# LANGUAGE DeriveGeneric, DerivingStrategies, DerivingVia #-}
+-- >
+-- > import qualified GHC.Generics as GHC
+-- > import Generics.SOP
+-- > import GHC.Generics (Generically (Generically))
+-- > data A = B Bool | C Int
+-- >   deriving stock GHC.Generic
+-- >   deriving Generic via Generically A
+--
+-- In the @-XDerivingVia@ case be careful to
+--
+-- 1. import the constructor of 'Generically'
+-- 2. import the correct module i.e. on base versions older than 4.17 which was
+--   first shipped with GHC 9.4.1 @import GHC.Generics.Generically (Generically (Generically))@
+--   from package [@generically@](https://hackage.haskell.org/package/generically)
+--
 -- = More examples
 --
 -- The best way to learn about how to define generic functions in the SOP style


### PR DESCRIPTION
- [x] allow deriving `via Generically` as such 
  ```haskell
  data A = B | C 
    deriving stock GHC.Generic
    deriving Generic via Generically A
  ```

- closes #153 
- [x] update on the documentation with a short section on deriving `Generic` 
![image](https://github.com/well-typed/generics-sop/assets/40720523/164e8718-6181-4a72-9709-c55da430b315)
- [x] [CI passes](https://github.com/MangoIV/generics-sop/actions/runs/6035728021)