### PR TITLE
Update collapse_NP so that hcollapse fuses

### DIFF
--- a/sop-core/CHANGELOG.md
+++ b/sop-core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 0.6.0.0
 
+* `collapse_NP` now uses `build` for list fusion. Added rewrite
+  rules for `collapse_NS` and `collapse_SOP` to optimize small
+  sums (up to 3 constructors).
+
 * Generalise the type signatures of cata- and anamorphisms
   to pass down the constraint dictionaries, as suggested
   in #144.

--- a/sop-core/src/Data/SOP/NP.hs
+++ b/sop-core/src/Data/SOP/NP.hs
@@ -96,6 +96,7 @@ import Unsafe.Coerce
 #if !MIN_VERSION_base(4,11,0)
 import Data.Semigroup (Semigroup (..))
 #endif
+import GHC.Exts (build)
 
 import Control.DeepSeq (NFData(..))
 
@@ -527,16 +528,25 @@ collapse_NP  ::              NP  (K a) xs  ->  [a]
 --
 collapse_POP :: SListI xss => POP (K a) xss -> [[a]]
 
-collapse_NP Nil         = []
-collapse_NP (K x :* xs) = x : collapse_NP xs
+collapse_NP np = build (\(c :: a -> r -> r) n ->
+  let go :: forall ys. NP (K a) ys -> r
+      go Nil           = n
+      go (K x :* xs) = x `c` go xs
+   in go np)
+{-# INLINE collapse_NP #-}
 
 collapse_POP = collapse_NP . hliftA (K . collapse_NP) . unPOP
+{-# INLINE collapse_POP #-}
 
 type instance CollapseTo NP  a = [a]
 type instance CollapseTo POP a = [[a]]
 
-instance HCollapse NP  where hcollapse = collapse_NP
-instance HCollapse POP where hcollapse = collapse_POP
+instance HCollapse NP  where
+  hcollapse = collapse_NP
+  {-# INLINE hcollapse #-}
+instance HCollapse POP where
+  hcollapse = collapse_POP
+  {-# INLINE hcollapse #-}
 
 -- * Folding
 

--- a/sop-core/src/Data/SOP/NS.hs
+++ b/sop-core/src/Data/SOP/NS.hs
@@ -576,14 +576,52 @@ collapse_SOP :: SListI xss => SOP (K a) xss ->  [a]
 
 collapse_NS (Z (K x)) = x
 collapse_NS (S xs)    = collapse_NS xs
+{-# NOINLINE collapse_NS #-}
 
 collapse_SOP = collapse_NS . hliftA (K . collapse_NP) . unSOP
+{-# INLINE [1] collapse_SOP #-}
+
+-- Note [Collapse fusion staging]
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-- collapse_NP participates in build/foldr fusion via GHC.List.build.
+--
+-- collapse_NS is recursive and cannot be inlined, so the NS and SOP
+-- collapse paths do not benefit from fusion on their own. It is marked
+-- NOINLINE simply to guarantee a stable target for rules.
+--
+-- We use RULES to short-circuit the common case of small sums, rewriting
+-- directly to unK or collapse_NP.
+--
+-- For the SOP rules to fire, hcollapse must inline first to expose the
+-- underlying collapse_SOP call, and collapse_SOP must remain visible
+-- long enough for the rules to match. We achieve this by inlining
+-- hcollapse early and holding collapse_SOP until phase 1.
+
+-- See Note [Collapse fusion staging]
+{-# RULES
+"collapse_NS/Z" [~1] forall x.
+  collapse_NS (Z x) = unK x
+"collapse_NS/SZ" [~1] forall x.
+  collapse_NS (S (Z x)) = unK x
+"collapse_NS/SSZ" [~1] forall x.
+  collapse_NS (S (S (Z x))) = unK x
+"collapse_SOP/Z" [~1] forall np.
+  collapse_SOP (SOP (Z np)) = collapse_NP np
+"collapse_SOP/SZ" [~1] forall np.
+  collapse_SOP (SOP (S (Z np))) = collapse_NP np
+"collapse_SOP/SSZ" [~1] forall np.
+  collapse_SOP (SOP (S (S (Z np)))) = collapse_NP np
+#-}
 
 type instance CollapseTo NS  a =  a
 type instance CollapseTo SOP a = [a]
 
-instance HCollapse NS  where hcollapse = collapse_NS
-instance HCollapse SOP where hcollapse = collapse_SOP
+instance HCollapse NS  where
+  hcollapse = collapse_NS
+  {-# INLINE [2] hcollapse #-}
+instance HCollapse SOP where
+  hcollapse = collapse_SOP
+  {-# INLINE [2] hcollapse #-}
 
 -- * Folding
 


### PR DESCRIPTION
Closes #187.

TL;DR: This PR introduces fusion for collapse_NP via GHC.Exts.build and adds rewrite rules for low-arity sums.

I've attached full sample file, core dumps, and timing dumps to this PR.

- This change results in a (modest) net reduction in code size for the sample file. 
- Compile time: Total allocation increases by roughly 10% across all compilation phases, concentrated in Simplifier passes 2–3 where the new INLINE pragmas and rewrite rules create more work. CodeGen allocation drops ~17%, consistent with smaller output. Total wall-clock time increases by ~10%. These are single-run numbers on a tiny module, so take the magnitudes with a grain of salt.

I tested on GHC 9.12.2.

## Changes

### `collapse_NP` now uses `GHC.Exts.build`

This results in noticeably tighter core for the simple case of `hcollapse` on `NP`. No intermediate list is allocated and there is only one loop.

Getting this to work requires `INLINE collapse_NP`. I added `INLINE hcollapse` to both the instance for NP and the instance for SOP. I debated a bit about this because the `hcollapse` methods seemed to inline reliably in my testing, but I think it will be more robust to be explicit about the desired behavior.

`INLINE hcollapse` should be a free dictionary elimination for both instances where it is possible and it is probably undesirable for GHC to ever fail to inline here.

Sample under test:

```haskell
testNP :: NP (K Int) '[(), (), (), (), ()]
testNP = K 1 :* K 2 :* K 3 :* K 4 :* K 5 :* Nil

consumeHcollapse_NP :: Int
consumeHcollapse_NP = sum . filter even . hcollapse $ testNP
```

Core diff:

```diff
--- diffs/consumehcollapse_np.before 2026-03-14 23:07:49.585684780 -0500
+++ diffs/consumehcollapse_np.after 2026-03-14 23:08:07.064822033 -0500
@@ -1,18 +1,16 @@
 Rec {
 $wgo3
-  = \ ds ww ->
-      case ds of {
-        [] -> ww;
-        : y ys ->
-          case y of { I# ipv ->
+  = \ @k1 @ys ds1 ww ->
+      case ds1 of {
+        Nil co -> ww;
+        :* @x @xs1 co ds2 xs2 ->
+          case ds2 `cast` <Co:4> :: ... of { I# ipv ->
           case remInt# ipv 2# of {
-            __DEFAULT -> $wgo3 ys ww;
-            0# -> $wgo3 ys (+# ww ipv)
+            __DEFAULT -> $wgo3 xs2 ww;
+            0# -> $wgo3 xs2 (+# ww ipv)
           }
           }
       }
 end Rec }

-lvl24 = collapse_NP testNP
-
-consumeHcollapse_NP = case $wgo3 lvl24 0# of ww { __DEFAULT -> I# ww }
+consumeHcollapse_NP = case $wgo3 testNP 0# of ww { __DEFAULT -> I# ww }

```

#### Inline `build` vs. RULES

Inline `build` gets transformed back into list traversal if fusion fails, so it is no worse than the current state of affairs in that regard.

This is likely a modest performance win.

In any case, no continuation or call to build is visible in the emitted core when fusion fails.

Haskell:

```haskell
testNP :: NP (K Int) '[(), (), (), (), ()]
testNP = K 1 :* K 2 :* K 3 :* K 4 :* K 5 :* Nil

opaque :: [a] -> [a]
opaque = id
{-# NOINLINE opaque #-}

consumehcollapse_NoFuse_NP :: Int
consumehcollapse_NoFuse_NP = sum . opaque . hcollapse $ testNP
```

Core diff:

```diff
--- diffs/consumenofuse_np.before 2026-03-14 23:11:57.604650496 -0500
+++ diffs/consumenofuse_np.after 2026-03-14 23:12:09.777748921 -0500
@@ -1,5 +1,14 @@
-lvl24 = collapse_NP testNP
+Rec {
+go
+  = \ @k1 @ys ds1 ->
+      case ds1 of {
+        Nil co -> [];
+        :* @x @xs1 co ds2 xs2 -> : (ds2 `cast` <Co:4> :: ...) (go xs2)
+      }
+end Rec }

-lvl25 = opaque lvl24
+lvl13 = go testNP

-consumeNoFuse_NP = case $wgo1 lvl25 0# of ww { __DEFAULT -> I# ww }
+lvl14 = opaque lvl13
+
+consumeNoFuse_NP = case $wgo1 lvl14 0# of ww { __DEFAULT -> I# ww }
```

#### Direct inlining vs. rewrite rules

A rules-based approach produces the same core output for my sample file as the direct inlining approach. The main trade offs I can come up with:

1. Direct inlining eliminates `collapse_NP` as a stable name for RULES. I don't think this is likely to be an issue but it could break downstream rules if anyone has written them.
2. Direct inlining eliminates a function call even in the failure case at the cost of slightly more code size.

### `NS` and `SOP` collapse implementations now have rewrite rules for small n

This might be a bit more controversial, but I noticed as I was working on this that the `NS` and `SOP` instances don't participate in fusion with this change.

Rules seem like a nice conservative choice that avoids the code and compile time bloat and implied by unfolding using a type class method.

Attempting to fix this wholesale is out of scope, _but_ if we introduce rewrite rules for small sums I think we get an outsized performance improvement in a lot of common `generics-sop` cases. I chose to implement rules for the first three layers of the sum, although I feel like even just one layer could have a meaningful impact.

I added separate rules for `SOP` and `NS` because I believe this will result in more reliable rule firing in practical use.

#### `NS`

This is a trivial case, but it constant folds outright instead of going through `collapse_NS` which cannot be inlined.

Sample under test:

```haskell
testNS_Z :: NS (K Int) '[(), (), ()]
testNS_Z = Z (K 59)

consumeCollapseNS_Z :: Int
consumeCollapseNS_Z = collapse_NS testNS_Z
```

Core diff:

```diff
--- diffs/consumecollapse_ns_z.before 2026-03-14 23:16:00.972618265 -0500
+++ diffs/consumecollapse_ns_z.after 2026-03-14 23:16:38.136918756 -0500
@@ -2,6 +2,6 @@

 testNS_Z = Z @~<Co:11> :: ... (testNS_Z1 `cast` <Co:5> :: ...)

-consumeCollapseNS_Z = collapse_NS testNS_Z
+consumeCollapseNS_Z = testNS_Z1

-main8 = case consumeCollapseNS_Z of { I# n -> itos n [] }
+main8 = $fShowCallStack_itos' 59# []
```

This extends to any S/Z layering for which I created a rule.

#### `SOP`

Marked improvement in core. Eliminates a traversal, an intermediate list, and several dictionaries. Also susceptible to constant folding.

Sample under test:

```haskell
testSOP_Z :: SOP (K Int) '[ '[(), (), ()]]
testSOP_Z = SOP (Z (K 10 :* K 20 :* K 30 :* Nil))

consumeCollapse_SOP_Z :: Int
consumeCollapse_SOP_Z = sum . hcollapse $ testSOP_Z
```

Core diff:

```diff
--- diffs/consumecollapse_sop_z.before 2026-03-14 23:19:35.286351117 -0500
+++ diffs/consumecollapse_sop_z.after 2026-03-14 23:43:21.903012229 -0500
@@ -1,9 +1,10 @@
-lvl15 = $w$cp2All $fAllkc[]
+Rec {
+$wgo
+  = \ @k1 @ys ds1 ww ->
+      case ds1 of {
+        Nil co -> ww;
+        :* @x @xs1 co ds2 xs2 -> case ds2 `cast` <Co:4> :: ... of { I# y -> $wgo xs2 (+# ww y) }
+      }
+end Rec }

-lvl16 = $wcpure_NP lvl15 ($fHCollapsekListSOP2 `cast` <Co:40> :: ...)
-
-lvl17 = ap_NS lvl16 testSOP_Z1

-
-lvl18 = collapse_NS lvl17
-
-consumeCollapseSOP_Z = case $wgo1 lvl18 0# of ww { __DEFAULT -> I# ww }
+consumeCollapseSOP_Z = case $wgo testSOP_Z2 0# of ww { __DEFAULT -> I# ww }
```

It's worth noting that this extends to SOPs with two or three constructors under my changes. All will share the same `$wgo` worker.

### `POP` collapse is now inlined

I did this simply for parity. It improves core along the same lines as the change to `collapse_NP` by fusing away the outer list, but will not fuse away the inner list as it stands. Rules could be introduced here, too, but I could not convince myself that small `POP`s are common enough to justify them. This may just be an artifact of my own use cases, though.

## Attachments

GitHub is restrictive about file types, so I've included the relevant files as summaries with nested code blocks.

### Sample.hs

<details>
<summary>Sample.hs</summary>

```haskell
{-# LANGUAGE DataKinds #-}
{-# LANGUAGE ScopedTypeVariables #-}
{-# OPTIONS_GHC -O2 -dsuppress-all -dsuppress-uniques -dppr-cols=200 #-}

module Main where

import Data.SOP.BasicFunctors
import Data.SOP.Classes
import Data.SOP.NP
import Data.SOP.NS

testNP :: NP (K Int) '[(), (), (), (), ()]
testNP = K 1 :* K 2 :* K 3 :* K 4 :* K 5 :* Nil

testPOP :: POP (K Int) '[ '[(), (), ()], '[(), (), ()]]
testPOP = POP ((K 48 :* K 27 :* K 90 :* Nil) :* (K 23 :* K 4 :* K 1 :* Nil) :* Nil)

testNS_Z :: NS (K Int) '[(), (), ()]
testNS_Z = Z (K 59)

testNS_SZ :: NS (K Int) '[(), (), ()]
testNS_SZ = S (Z (K 42))

testNS_SSZ :: NS (K Int) '[(), (), ()]
testNS_SSZ = S (S (Z (K 17)))

testSOP_Z :: SOP (K Int) '[ '[(), (), ()]]
testSOP_Z = SOP (Z (K 10 :* K 20 :* K 30 :* Nil))

testSOP_SZ :: SOP (K Int) '[ '[], '[(), (), (), ()]]
testSOP_SZ = SOP (S (Z (K 7 :* K 14 :* K 21 :* K 28 :* Nil)))

testSOP_SSZ :: SOP (K Int) '[ '[], '[], '[(), ()]]
testSOP_SSZ = SOP (S (S (Z (K 3 :* K 6 :* Nil))))

-- 4 constructors: beyond rule coverage, exercises the fallback path.
testSOP_SSSZ :: SOP (K Int) '[ '[], '[], '[], '[(), ()]]
testSOP_SSSZ = SOP (S (S (S (Z (K 11 :* K 22 :* Nil)))))

opaque :: [a] -> [a]
opaque = id
{-# NOINLINE opaque #-}

consumeHcollapse_NP :: Int
consumeHcollapse_NP = sum . filter even . hcollapse $ testNP
{-# NOINLINE consumeHcollapse_NP #-}

consumeNoFuse_NP :: Int
consumeNoFuse_NP = sum . opaque . hcollapse $ testNP
{-# NOINLINE consumeNoFuse_NP #-}

consumeHcollapse_POP :: Int
consumeHcollapse_POP = sum . filter even . map sum . hcollapse $ testPOP
{-# NOINLINE consumeHcollapse_POP #-}

consumeCollapseNS_Z :: Int
consumeCollapseNS_Z = collapse_NS testNS_Z
{-# NOINLINE consumeCollapseNS_Z #-}

consumeCollapseNS_SZ :: Int
consumeCollapseNS_SZ = collapse_NS testNS_SZ
{-# NOINLINE consumeCollapseNS_SZ #-}

consumeCollapseNS_SSZ :: Int
consumeCollapseNS_SSZ = collapse_NS testNS_SSZ
{-# NOINLINE consumeCollapseNS_SSZ #-}

consumeCollapseSOP_Z :: Int
consumeCollapseSOP_Z = sum . hcollapse $ testSOP_Z
{-# NOINLINE consumeCollapseSOP_Z #-}

consumeCollapseSOP_SZ :: Int
consumeCollapseSOP_SZ = sum . hcollapse $ testSOP_SZ
{-# NOINLINE consumeCollapseSOP_SZ #-}

consumeCollapseSOP_SSZ :: Int
consumeCollapseSOP_SSZ = sum . hcollapse $ testSOP_SSZ
{-# NOINLINE consumeCollapseSOP_SSZ #-}

-- Beyond rule coverage: exercises the fallback path.
consumeCollapseSOP_SSSZ :: Int
consumeCollapseSOP_SSSZ = sum . hcollapse $ testSOP_SSSZ
{-# NOINLINE consumeCollapseSOP_SSSZ #-}

main :: IO ()
main = do
    print consumeHcollapse_NP
    print consumeNoFuse_NP
    print consumeHcollapse_POP
    print consumeCollapseNS_Z
    print consumeCollapseNS_SZ
    print consumeCollapseNS_SSZ
    print consumeCollapseSOP_Z
    print consumeCollapseSOP_SZ
    print consumeCollapseSOP_SSZ
    print consumeCollapseSOP_SSSZ
```

</details>

### Core dumps


<details>
<summary>Before</summary>

```haskell

==================== Tidy Core ====================

Result size of Tidy Core = {terms: 646, types: 3,976, coercions: 988, joins: 2/2}

$dAll = $fAllac: $fTopkx $fAllkc[]

$dAll1 = $fAllac: $fTopkx $dAll

$dAll2 = $fAllac: $fTopkx $dAll1

$dAll3 = $fAllac: $dAll1 $fAllkc[]

$dAll4 = $fAllac: $fAllkc[] $dAll3

testNP9 = I# 1#

testNP8 = I# 2#

testNP7 = I# 3#

testNP6 = I# 4#

testNP5 = I# 5#

testNP4 = :* @~<Co:5> :: ... (testNP5 `cast` <Co:5> :: ...) $WNil

testNP3 = :* @~<Co:8> :: ... (testNP6 `cast` <Co:5> :: ...) testNP4

testNP2 = :* @~<Co:11> :: ... (testNP7 `cast` <Co:5> :: ...) testNP3

testNP1 = :* @~<Co:14> :: ... (testNP8 `cast` <Co:5> :: ...) testNP2

testNP = :* @~<Co:17> :: ... (testNP9 `cast` <Co:5> :: ...) testNP1

testPOP12 = I# 48#

testPOP11 = I# 27#

testPOP10 = I# 90#

testPOP9 = :* @~<Co:5> :: ... (testPOP10 `cast` <Co:5> :: ...) $WNil

testPOP8 = :* @~<Co:8> :: ... (testPOP11 `cast` <Co:5> :: ...) testPOP9

testPOP7 = :* @~<Co:11> :: ... (testPOP12 `cast` <Co:5> :: ...) testPOP8

testPOP6 = I# 23#

testPOP5 = :* @~<Co:5> :: ... (testNP9 `cast` <Co:5> :: ...) $WNil

testPOP4 = :* @~<Co:8> :: ... (testNP6 `cast` <Co:5> :: ...) testPOP5

testPOP3 = :* @~<Co:11> :: ... (testPOP6 `cast` <Co:5> :: ...) testPOP4

testPOP2 = :* @~<Co:17> :: ... testPOP3 $WNil

testPOP1 = :* @~<Co:31> :: ... testPOP7 testPOP2

testPOP = testPOP1 `cast` <Co:37> :: ...

testNS_Z1 = I# 59#

testNS_Z = Z @~<Co:11> :: ... (testNS_Z1 `cast` <Co:5> :: ...)

consumeCollapseNS_Z = collapse_NS testNS_Z

testNS_SZ2 = I# 42#

testNS_SZ1 = Z @~<Co:8> :: ... (testNS_SZ2 `cast` <Co:5> :: ...)

testNS_SZ = S @~<Co:11> :: ... testNS_SZ1

consumeCollapseNS_SZ = collapse_NS testNS_SZ

testNS_SSZ3 = I# 17#

testNS_SSZ2 = Z @~<Co:5> :: ... (testNS_SSZ3 `cast` <Co:5> :: ...)

testNS_SSZ1 = S @~<Co:8> :: ... testNS_SSZ2

testNS_SSZ = S @~<Co:11> :: ... testNS_SSZ1

consumeCollapseNS_SSZ = collapse_NS testNS_SSZ

testSOP_Z7 = I# 10#

testSOP_Z6 = I# 20#

testSOP_Z5 = I# 30#

testSOP_Z4 = :* @~<Co:5> :: ... (testSOP_Z5 `cast` <Co:5> :: ...) $WNil

testSOP_Z3 = :* @~<Co:8> :: ... (testSOP_Z6 `cast` <Co:5> :: ...) testSOP_Z4

testSOP_Z2 = :* @~<Co:11> :: ... (testSOP_Z7 `cast` <Co:5> :: ...) testSOP_Z3

testSOP_Z1 = Z @~<Co:17> :: ... testSOP_Z2

testSOP_Z = testSOP_Z1 `cast` <Co:23> :: ...

testSOP_SZ10 = I# 7#

testSOP_SZ9 = I# 14#

testSOP_SZ8 = I# 21#

testSOP_SZ7 = I# 28#

testSOP_SZ6 = :* @~<Co:5> :: ... (testSOP_SZ7 `cast` <Co:5> :: ...) $WNil

testSOP_SZ5 = :* @~<Co:8> :: ... (testSOP_SZ8 `cast` <Co:5> :: ...) testSOP_SZ6

testSOP_SZ4 = :* @~<Co:11> :: ... (testSOP_SZ9 `cast` <Co:5> :: ...) testSOP_SZ5

testSOP_SZ3 = :* @~<Co:14> :: ... (testSOP_SZ10 `cast` <Co:5> :: ...) testSOP_SZ4

testSOP_SZ2 = Z @~<Co:20> :: ... testSOP_SZ3

testSOP_SZ1 = S @~<Co:25> :: ... testSOP_SZ2

testSOP_SZ = testSOP_SZ1 `cast` <Co:31> :: ...

testSOP_SSZ6 = I# 6#

testSOP_SSZ5 = :* @~<Co:5> :: ... (testSOP_SSZ6 `cast` <Co:5> :: ...) $WNil

testSOP_SSZ4 = :* @~<Co:8> :: ... (testNP7 `cast` <Co:5> :: ...) testSOP_SSZ5

testSOP_SSZ3 = Z @~<Co:14> :: ... testSOP_SSZ4

testSOP_SSZ2 = S @~<Co:19> :: ... testSOP_SSZ3

testSOP_SSZ1 = S @~<Co:24> :: ... testSOP_SSZ2

testSOP_SSZ = testSOP_SSZ1 `cast` <Co:30> :: ...

testSOP_SSSZ8 = I# 11#

testSOP_SSSZ7 = I# 22#

testSOP_SSSZ6 = :* @~<Co:5> :: ... (testSOP_SSSZ7 `cast` <Co:5> :: ...) $WNil

testSOP_SSSZ5 = :* @~<Co:8> :: ... (testSOP_SSSZ8 `cast` <Co:5> :: ...) testSOP_SSSZ6

testSOP_SSSZ4 = Z @~<Co:14> :: ... testSOP_SSSZ5

testSOP_SSSZ3 = S @~<Co:19> :: ... testSOP_SSSZ4

testSOP_SSSZ2 = S @~<Co:24> :: ... testSOP_SSSZ3

testSOP_SSSZ1 = S @~<Co:29> :: ... testSOP_SSSZ2

testSOP_SSSZ = testSOP_SSSZ1 `cast` <Co:35> :: ...

opaque = \ @a -> id

$trModule4 = "main"#

$trModule3 = TrNameS $trModule4

$trModule2 = "Main"#

$trModule1 = TrNameS $trModule2

$trModule = Module $trModule3 $trModule1

Rec {
$wgo1
  = \ ds ww ->
      case ds of {
        [] -> ww;
        : y ys -> case y of { I# y1 -> $wgo1 ys (+# ww y1) }
      }
end Rec }

lvl = $fAllac: $fAllkc[] $dAll4

lvl1 = $w$cp2All lvl

lvl2 = $wcpure_NP lvl1 ($fHCollapsekListSOP2 `cast` <Co:40> :: ...)

lvl3 = ap_NS lvl2 testSOP_SSSZ1

lvl4 = collapse_NS lvl3

consumeCollapseSOP_SSSZ = case $wgo1 lvl4 0# of ww { __DEFAULT -> I# ww }

lvl5 = $w$cp2All $dAll4

lvl6 = $wcpure_NP lvl5 ($fHCollapsekListSOP2 `cast` <Co:40> :: ...)

lvl7 = ap_NS lvl6 testSOP_SSZ1

lvl8 = collapse_NS lvl7

consumeCollapseSOP_SSZ = case $wgo1 lvl8 0# of ww { __DEFAULT -> I# ww }

lvl9 = $fAllac: $fTopkx $dAll2

lvl10 = $fAllac: lvl9 $fAllkc[]

lvl11 = $w$cp2All lvl10

lvl12 = $wcpure_NP lvl11 ($fHCollapsekListSOP2 `cast` <Co:40> :: ...)

lvl13 = ap_NS lvl12 testSOP_SZ1

lvl14 = collapse_NS lvl13

consumeCollapseSOP_SZ = case $wgo1 lvl14 0# of ww { __DEFAULT -> I# ww }

lvl15 = $w$cp2All $fAllkc[]

lvl16 = $wcpure_NP lvl15 ($fHCollapsekListSOP2 `cast` <Co:40> :: ...)

lvl17 = ap_NS lvl16 testSOP_Z1

lvl18 = collapse_NS lvl17

consumeCollapseSOP_Z = case $wgo1 lvl18 0# of ww { __DEFAULT -> I# ww }

Rec {
$wgo2
  = \ ds ww ->
      case ds of {
        [] -> ww;
        : y ys ->
          join {
            $j ipv
              = case remInt# ipv 2# of {
                  __DEFAULT -> $wgo2 ys ww;
                  0# -> $wgo2 ys (+# ww ipv)
                } } in
          joinrec {
            $wgo4 ds1 ww1
              = case ds1 of {
                  [] -> jump $j ww1;
                  : y1 ys1 -> case y1 of { I# y2 -> jump $wgo4 ys1 (+# ww1 y2) }
                }; } in
          jump $wgo4 y 0#
      }
end Rec }

lvl19 = $fAllac: $dAll2 $fAllkc[]

lvl20 = $w$cp2All lvl19

lvl21 = $wcpure_NP lvl20 ($fHCollapsekListPOP2 `cast` <Co:40> :: ...)

lvl22 = ap_NP lvl21 testPOP1

lvl23 = collapse_NP lvl22

consumeHcollapse_POP = case $wgo2 lvl23 0# of ww { __DEFAULT -> I# ww }

Rec {
$wgo3
  = \ ds ww ->
      case ds of {
        [] -> ww;
        : y ys ->
          case y of { I# ipv ->
          case remInt# ipv 2# of {
            __DEFAULT -> $wgo3 ys ww;
            0# -> $wgo3 ys (+# ww ipv)
          }
          }
      }
end Rec }

lvl24 = collapse_NP testNP

consumeHcollapse_NP = case $wgo3 lvl24 0# of ww { __DEFAULT -> I# ww }

lvl25 = opaque lvl24

consumeNoFuse_NP = case $wgo1 lvl25 0# of ww { __DEFAULT -> I# ww }

main2 = case consumeCollapseSOP_SSSZ of { I# n -> itos n [] }

main3 = case consumeCollapseSOP_SSZ of { I# n -> itos n [] }

main4 = case consumeCollapseSOP_SZ of { I# n -> itos n [] }

main5 = case consumeCollapseSOP_Z of { I# n -> itos n [] }

main6 = case consumeCollapseNS_SSZ of { I# n -> itos n [] }

main7 = case consumeCollapseNS_SZ of { I# n -> itos n [] }

main8 = case consumeCollapseNS_Z of { I# n -> itos n [] }

main9 = case consumeHcollapse_POP of { I# n -> itos n [] }

main10 = case consumeNoFuse_NP of { I# n -> itos n [] }

main11 = case consumeHcollapse_NP of { I# n -> itos n [] }

main1
  = \ s ->
      case hPutStr2 stdout main11 True s of { (# ipv, _ #) ->
      case hPutStr2 stdout main10 True ipv of { (# ipv2, _ #) ->
      case hPutStr2 stdout main9 True ipv2 of { (# ipv4, _ #) ->
      case hPutStr2 stdout main8 True ipv4 of { (# ipv6, _ #) ->
      case hPutStr2 stdout main7 True ipv6 of { (# ipv8, _ #) ->
      case hPutStr2 stdout main6 True ipv8 of { (# ipv10, _ #) ->
      case hPutStr2 stdout main5 True ipv10 of { (# ipv12, _ #) ->
      case hPutStr2 stdout main4 True ipv12 of { (# ipv14, _ #) ->
      case hPutStr2 stdout main3 True ipv14 of { (# ipv16, _ #) -> hPutStr2 stdout main2 True ipv16 }
      }
      }
      }
      }
      }
      }
      }
      }

main = main1 `cast` <Co:3> :: ...

main12 = runMainIO1 (main1 `cast` <Co:3> :: ...)

main = main12 `cast` <Co:3> :: ...
```

</details>

<details>
<summary>After</summary>

```haskell

==================== Tidy Core ====================

Result size of Tidy Core = {terms: 622, types: 3,443, coercions: 885, joins: 2/2}

$dAll = $fAllac: $fTopkx $fAllkc[]

$dAll1 = $fAllac: $fTopkx $dAll

testNP9 = I# 1#

testNP8 = I# 2#

testNP7 = I# 3#

testNP6 = I# 4#

testNP5 = I# 5#

testNP4 = :* @~<Co:5> :: ... (testNP5 `cast` <Co:5> :: ...) $WNil

testNP3 = :* @~<Co:8> :: ... (testNP6 `cast` <Co:5> :: ...) testNP4

testNP2 = :* @~<Co:11> :: ... (testNP7 `cast` <Co:5> :: ...) testNP3

testNP1 = :* @~<Co:14> :: ... (testNP8 `cast` <Co:5> :: ...) testNP2

testNP = :* @~<Co:17> :: ... (testNP9 `cast` <Co:5> :: ...) testNP1

testPOP12 = I# 48#

testPOP11 = I# 27#

testPOP10 = I# 90#

testPOP9 = :* @~<Co:5> :: ... (testPOP10 `cast` <Co:5> :: ...) $WNil

testPOP8 = :* @~<Co:8> :: ... (testPOP11 `cast` <Co:5> :: ...) testPOP9

testPOP7 = :* @~<Co:11> :: ... (testPOP12 `cast` <Co:5> :: ...) testPOP8

testPOP6 = I# 23#

testPOP5 = :* @~<Co:5> :: ... (testNP9 `cast` <Co:5> :: ...) $WNil

testPOP4 = :* @~<Co:8> :: ... (testNP6 `cast` <Co:5> :: ...) testPOP5

testPOP3 = :* @~<Co:11> :: ... (testPOP6 `cast` <Co:5> :: ...) testPOP4

testPOP2 = :* @~<Co:17> :: ... testPOP3 $WNil

testPOP1 = :* @~<Co:31> :: ... testPOP7 testPOP2

testPOP = testPOP1 `cast` <Co:37> :: ...

testNS_Z1 = I# 59#

testNS_Z = Z @~<Co:11> :: ... (testNS_Z1 `cast` <Co:5> :: ...)

consumeCollapseNS_Z = testNS_Z1

testNS_SZ2 = I# 42#

testNS_SZ1 = Z @~<Co:8> :: ... (testNS_SZ2 `cast` <Co:5> :: ...)

testNS_SZ = S @~<Co:11> :: ... testNS_SZ1

consumeCollapseNS_SZ = testNS_SZ2

testNS_SSZ3 = I# 17#

testNS_SSZ2 = Z @~<Co:5> :: ... (testNS_SSZ3 `cast` <Co:5> :: ...)

testNS_SSZ1 = S @~<Co:8> :: ... testNS_SSZ2

testNS_SSZ = S @~<Co:11> :: ... testNS_SSZ1

consumeCollapseNS_SSZ = testNS_SSZ3

testSOP_Z7 = I# 10#

testSOP_Z6 = I# 20#

testSOP_Z5 = I# 30#

testSOP_Z4 = :* @~<Co:5> :: ... (testSOP_Z5 `cast` <Co:5> :: ...) $WNil

testSOP_Z3 = :* @~<Co:8> :: ... (testSOP_Z6 `cast` <Co:5> :: ...) testSOP_Z4

testSOP_Z2 = :* @~<Co:11> :: ... (testSOP_Z7 `cast` <Co:5> :: ...) testSOP_Z3

testSOP_Z1 = Z @~<Co:17> :: ... testSOP_Z2

testSOP_Z = testSOP_Z1 `cast` <Co:23> :: ...

testSOP_SZ10 = I# 7#

testSOP_SZ9 = I# 14#

testSOP_SZ8 = I# 21#

testSOP_SZ7 = I# 28#

testSOP_SZ6 = :* @~<Co:5> :: ... (testSOP_SZ7 `cast` <Co:5> :: ...) $WNil

testSOP_SZ5 = :* @~<Co:8> :: ... (testSOP_SZ8 `cast` <Co:5> :: ...) testSOP_SZ6

testSOP_SZ4 = :* @~<Co:11> :: ... (testSOP_SZ9 `cast` <Co:5> :: ...) testSOP_SZ5

testSOP_SZ3 = :* @~<Co:14> :: ... (testSOP_SZ10 `cast` <Co:5> :: ...) testSOP_SZ4

testSOP_SZ2 = Z @~<Co:20> :: ... testSOP_SZ3

testSOP_SZ1 = S @~<Co:25> :: ... testSOP_SZ2

testSOP_SZ = testSOP_SZ1 `cast` <Co:31> :: ...

testSOP_SSZ6 = I# 6#

testSOP_SSZ5 = :* @~<Co:5> :: ... (testSOP_SSZ6 `cast` <Co:5> :: ...) $WNil

testSOP_SSZ4 = :* @~<Co:8> :: ... (testNP7 `cast` <Co:5> :: ...) testSOP_SSZ5

testSOP_SSZ3 = Z @~<Co:14> :: ... testSOP_SSZ4

testSOP_SSZ2 = S @~<Co:19> :: ... testSOP_SSZ3

testSOP_SSZ1 = S @~<Co:24> :: ... testSOP_SSZ2

testSOP_SSZ = testSOP_SSZ1 `cast` <Co:30> :: ...

testSOP_SSSZ8 = I# 11#

testSOP_SSSZ7 = I# 22#

testSOP_SSSZ6 = :* @~<Co:5> :: ... (testSOP_SSSZ7 `cast` <Co:5> :: ...) $WNil

testSOP_SSSZ5 = :* @~<Co:8> :: ... (testSOP_SSSZ8 `cast` <Co:5> :: ...) testSOP_SSSZ6

testSOP_SSSZ4 = Z @~<Co:14> :: ... testSOP_SSSZ5

testSOP_SSSZ3 = S @~<Co:19> :: ... testSOP_SSSZ4

testSOP_SSSZ2 = S @~<Co:24> :: ... testSOP_SSSZ3

testSOP_SSSZ1 = S @~<Co:29> :: ... testSOP_SSSZ2

testSOP_SSSZ = testSOP_SSSZ1 `cast` <Co:35> :: ...

opaque = \ @a -> id

$trModule4 = "main"#

$trModule3 = TrNameS $trModule4

$trModule2 = "Main"#

$trModule1 = TrNameS $trModule2

$trModule = Module $trModule3 $trModule1

Rec {
$wgo1
  = \ ds ww ->
      case ds of {
        [] -> ww;
        : y ys -> case y of { I# y1 -> $wgo1 ys (+# ww y1) }
      }
end Rec }

lvl = $fAllac: $dAll1 $fAllkc[]

lvl1 = $fAllac: $fAllkc[] lvl

lvl2 = $fAllac: $fAllkc[] lvl1

lvl3 = $w$cp2All lvl2

lvl4 = \ @a1 _ eta -> collapse_NP eta

lvl5 = $wcpure_NP lvl3 (lvl4 `cast` <Co:40> :: ...)

lvl6 = ap_NS lvl5 testSOP_SSSZ1

lvl7 = collapse_NS lvl6

consumeCollapseSOP_SSSZ = case $wgo1 lvl7 0# of ww { __DEFAULT -> I# ww }

Rec {
$wgo
  = \ @k1 @ys ds1 ww ->
      case ds1 of {
        Nil co -> ww;
        :* @x @xs1 co ds2 xs2 -> case ds2 `cast` <Co:4> :: ... of { I# y -> $wgo xs2 (+# ww y) }
      }
end Rec }

consumeCollapseSOP_SSZ = case $wgo testSOP_SSZ4 0# of ww { __DEFAULT -> I# ww }

consumeCollapseSOP_SZ = case $wgo testSOP_SZ3 0# of ww { __DEFAULT -> I# ww }

consumeCollapseSOP_Z = case $wgo testSOP_Z2 0# of ww { __DEFAULT -> I# ww }

Rec {
$wgo2
  = \ @k1 @ys ds1 ww ->
      case ds1 of {
        Nil co -> ww;
        :* @x @xs1 co ds2 xs2 ->
          join {
            $j ipv
              = case remInt# ipv 2# of {
                  __DEFAULT -> $wgo2 xs2 ww;
                  0# -> $wgo2 xs2 (+# ww ipv)
                } } in
          joinrec {
            $wgo4 ds ww1
              = case ds of {
                  [] -> jump $j ww1;
                  : y ys1 -> case y of { I# y1 -> jump $wgo4 ys1 (+# ww1 y1) }
                }; } in
          jump $wgo4 (ds2 `cast` <Co:5> :: ...) 0#
      }
end Rec }

lvl8 = $fAllac: $fTopkx $dAll1

lvl9 = $fAllac: lvl8 $fAllkc[]

lvl10 = $w$cp2All lvl9

lvl11 = $wcpure_NP lvl10 (lvl4 `cast` <Co:40> :: ...)

lvl12 = ap_NP lvl11 testPOP1

consumeHcollapse_POP = case $wgo2 lvl12 0# of ww { __DEFAULT -> I# ww }

Rec {
$wgo3
  = \ @k1 @ys ds1 ww ->
      case ds1 of {
        Nil co -> ww;
        :* @x @xs1 co ds2 xs2 ->
          case ds2 `cast` <Co:4> :: ... of { I# ipv ->
          case remInt# ipv 2# of {
            __DEFAULT -> $wgo3 xs2 ww;
            0# -> $wgo3 xs2 (+# ww ipv)
          }
          }
      }
end Rec }

consumeHcollapse_NP = case $wgo3 testNP 0# of ww { __DEFAULT -> I# ww }

Rec {
go
  = \ @k1 @ys ds1 ->
      case ds1 of {
        Nil co -> [];
        :* @x @xs1 co ds2 xs2 -> : (ds2 `cast` <Co:4> :: ...) (go xs2)
      }
end Rec }

lvl13 = go testNP

lvl14 = opaque lvl13

consumeNoFuse_NP = case $wgo1 lvl14 0# of ww { __DEFAULT -> I# ww }

main2 = case consumeCollapseSOP_SSSZ of { I# n -> itos n [] }

main3 = case consumeCollapseSOP_SSZ of { I# n -> itos n [] }

main4 = case consumeCollapseSOP_SZ of { I# n -> itos n [] }

main5 = case consumeCollapseSOP_Z of { I# n -> itos n [] }

main6 = $fShowCallStack_itos' 17# []

main7 = $fShowCallStack_itos' 42# []

main8 = $fShowCallStack_itos' 59# []

main9 = case consumeHcollapse_POP of { I# n -> itos n [] }

main10 = case consumeNoFuse_NP of { I# n -> itos n [] }

main11 = case consumeHcollapse_NP of { I# n -> itos n [] }

main1
  = \ s ->
      case hPutStr2 stdout main11 True s of { (# ipv, _ #) ->
      case hPutStr2 stdout main10 True ipv of { (# ipv2, _ #) ->
      case hPutStr2 stdout main9 True ipv2 of { (# ipv4, _ #) ->
      case hPutStr2 stdout main8 True ipv4 of { (# ipv6, _ #) ->
      case hPutStr2 stdout main7 True ipv6 of { (# ipv8, _ #) ->
      case hPutStr2 stdout main6 True ipv8 of { (# ipv10, _ #) ->
      case hPutStr2 stdout main5 True ipv10 of { (# ipv12, _ #) ->
      case hPutStr2 stdout main4 True ipv12 of { (# ipv14, _ #) ->
      case hPutStr2 stdout main3 True ipv14 of { (# ipv16, _ #) -> hPutStr2 stdout main2 True ipv16 }
      }
      }
      }
      }
      }
      }
      }
      }

main = main1 `cast` <Co:3> :: ...

main12 = runMainIO1 (main1 `cast` <Co:3> :: ...)

main = main12 `cast` <Co:3> :: ...
```

</details>

### Timings

<details>
<summary>Before</summary>

```
initializing unit database: alloc=6085056 time=8.013
Chasing dependencies: alloc=3510536 time=0.915
systool:cc: alloc=140016 time=0.262
systool:cc: alloc=113408 time=0.132
systool:linker: alloc=5592896 time=1.359
Parser [Main]: alloc=5025848 time=0.933
ConsistencyCheck [Main]: alloc=15424 time=0.010
Renamer/typechecker [Main]: alloc=34384160 time=25.406
Desugar [Main]: alloc=901136 time=0.187
Simplifier [Main]: alloc=41724296 time=15.187
Specialise [Main]: alloc=2527680 time=0.631
Float out(FOS {Lam = Just 0, Consts = True, JoinsToTop = False, OverSatApps = False}) [Main]: alloc=1257552 time=0.803
Simplifier [Main]: alloc=10318584 time=2.607
Simplifier [Main]: alloc=9842704 time=2.218
Simplifier [Main]: alloc=18437008 time=20.545
Float inwards [Main]: alloc=5328 time=0.004
Called arity analysis [Main]: alloc=5376 time=0.002
Simplifier [Main]: alloc=11077352 time=2.228
Demand analysis (including Boxity) [Main]: alloc=1003816 time=0.314
Constructed Product Result analysis [Main]: alloc=265856 time=0.079
Worker Wrapper binds [Main]: alloc=195952 time=0.047
Simplifier [Main]: alloc=21406768 time=4.488
Exitification transformation [Main]: alloc=5320 time=0.003
Float out(FOS {Lam = Just 0, Consts = True, JoinsToTop = True, OverSatApps = True}) [Main]: alloc=1422352 time=0.333
Common sub-expression [Main]: alloc=5352 time=0.003
Float inwards [Main]: alloc=5328 time=0.002
Simplifier [Main]: alloc=11407872 time=2.795
Liberate case [Main]: alloc=5336 time=0.003
Simplifier [Main]: alloc=2799880 time=0.673
SpecConstr [Main]: alloc=766392 time=0.139
Simplifier [Main]: alloc=2468096 time=0.633
Common sub-expression [Main]: alloc=5352 time=0.002
Simplifier [Main]: alloc=10471536 time=2.226
Demand analysis [Main]: alloc=906904 time=0.252
CoreTidy [Main]: alloc=1519912 time=0.420
LatePlugins [Main]: alloc=800 time=0.002
CorePrep [Main]: alloc=588224 time=0.119
CoreToStg [Main]: alloc=2300216 time=0.476
CodeGen [Main]: alloc=40360944 time=14.912
WriteIface [Sample.hi]: alloc=1076216 time=0.145
systool:as: alloc=74352 time=0.181
```

</details>

<details>
<summary>After</summary>

```
initializing unit database: alloc=6085056 time=8.712
Chasing dependencies: alloc=3435432 time=0.961
systool:cc: alloc=140016 time=0.225
systool:cc: alloc=113408 time=0.165
systool:linker: alloc=5591448 time=2.788
Parser [Main]: alloc=4867616 time=2.259
ConsistencyCheck [Main]: alloc=15424 time=0.011
Renamer/typechecker [Main]: alloc=34417960 time=27.638
Desugar [Main]: alloc=900976 time=0.189
Simplifier [Main]: alloc=44892200 time=15.924
Specialise [Main]: alloc=2746736 time=1.032
Float out(FOS {Lam = Just 0, Consts = True, JoinsToTop = False, OverSatApps = False}) [Main]: alloc=1344328 time=0.362
Simplifier [Main]: alloc=21360080 time=5.940
Simplifier [Main]: alloc=18421384 time=19.750
Simplifier [Main]: alloc=19236736 time=4.125
Float inwards [Main]: alloc=5328 time=0.003
Called arity analysis [Main]: alloc=5376 time=0.002
Simplifier [Main]: alloc=11729856 time=2.280
Demand analysis (including Boxity) [Main]: alloc=1049992 time=0.332
Constructed Product Result analysis [Main]: alloc=276088 time=0.086
Worker Wrapper binds [Main]: alloc=212136 time=0.052
Simplifier [Main]: alloc=22592384 time=4.594
Exitification transformation [Main]: alloc=5320 time=0.003
Float out(FOS {Lam = Just 0, Consts = True, JoinsToTop = True, OverSatApps = True}) [Main]: alloc=1491880 time=0.407
Common sub-expression [Main]: alloc=5352 time=0.003
Float inwards [Main]: alloc=5328 time=0.001
Simplifier [Main]: alloc=11367832 time=2.565
Liberate case [Main]: alloc=5336 time=0.003
Simplifier [Main]: alloc=2826800 time=0.694
SpecConstr [Main]: alloc=824672 time=0.192
Simplifier [Main]: alloc=9780472 time=1.996
Common sub-expression [Main]: alloc=5352 time=0.003
Simplifier [Main]: alloc=10417624 time=2.541
Demand analysis [Main]: alloc=993320 time=0.287
CoreTidy [Main]: alloc=1457216 time=0.424
LatePlugins [Main]: alloc=800 time=0.002
CorePrep [Main]: alloc=553696 time=0.117
CoreToStg [Main]: alloc=2254976 time=0.507
CodeGen [Main]: alloc=33482528 time=12.643
WriteIface [Sample.hi]: alloc=1076216 time=0.147
systool:as: alloc=74352 time=0.153
```
</details>